### PR TITLE
Set and retrieve the path to the git binary used by this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Ruby Git
+# RubyGit
 
 **THIS PROJECT IS A WORK IN PROGRESS AND IS NOT USEFUL IN ITS CURRENT STATE**
 
 [![Build Status](https://travis-ci.org/jcouball/ruby_git.svg?branch=main)](https://travis-ci.org/jcouball/ruby_git)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2d8d52a55d655b6a3def/maintainability)](https://codeclimate.com/github/jcouball/ruby_git/maintainability)
 
-Ruby Git is an object-oriented wrapper for the `git` command line tool for working with Worktrees
+RubyGit is an object-oriented wrapper for the `git` command line tool for working with Worktrees
 and Repositories. It tries to make more sense out of the Git command line. 
 
 ## Installation
@@ -25,6 +25,16 @@ Or install it directly from the command line:
     $ gem install ruby_git
 
 ## Usage
+
+To configure RubyGit:
+
+```Ruby
+RubyGit.git.path = '/usr/local/bin/git'
+
+# Returns the user set path or searches for 'git' in ENV['PATH']
+RubyGit.git.path #=> '/usr/local/bin/git'
+RubyGit.git.version #=> [2,28,0]
+```
 
 To work with an existing Worktree:
 

--- a/lib/ruby_git.rb
+++ b/lib/ruby_git.rb
@@ -1,7 +1,27 @@
 # frozen_string_literal: true
 
 require 'ruby_git/version'
+require 'ruby_git/file_helpers'
+require 'ruby_git/git_binary'
 
+# RubyGit is an object-oriented wrapper for the `git` command line tool for
+# working with Worktrees and Repositories. It tries to make more sense out
+# of the Git command line.
+#
+# @api public
+#
 module RubyGit
-  class Error < StandardError; end
+  # Return information about the git binary used by this library
+  #
+  # Use this object to set the path to the git binary to use or to see the
+  # path being used.
+  #
+  # @example Setting the git binary path
+  #    RubyGit.git.path = '/usr/local/bin/git'
+  #
+  # @return [RubyGit::GitBinary]
+  #
+  def self.git
+    (@git ||= RubyGit::GitBinary.new)
+  end
 end

--- a/lib/ruby_git/file_helpers.rb
+++ b/lib/ruby_git/file_helpers.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module RubyGit
+  # A namespace for several file utility methods that I wish were part of FileUtils.
+  #
+  # @api public
+  #
+  module FileHelpers
+    # Cross platform way to find an executable file within a list of paths
+    #
+    # Works for both Linux/Unix and Windows.
+    #
+    # @example Searching over the PATH for a command
+    #   path = FileUtils.which('git')
+    #
+    # @example Overriding the default PATH
+    #   path = FileUtils.which('git', ['/usr/bin', '/usr/local/bin'])
+    #
+    # @param [String] cmd The basename of the executable file to search for
+    # @param [Array<String>] paths The list of directories to search for basename in
+    # @param [Array<String>] exts The list of extensions that indicate that a file is executable
+    #
+    # `exts` is for Windows. Other platforms should accept the default.
+    #
+    # @return [Pathname,nil] The path to the first executable file found on the path or
+    #   nil an executable file was not found.
+    #
+    def self.which(
+      cmd,
+      paths: ENV['PATH'].split(File::PATH_SEPARATOR),
+      exts: (ENV['PATHEXT']&.split(';') || [''])
+    )
+      raise 'PATH is not set' unless ENV.keys.include?('PATH')
+
+      paths
+        .product(exts)
+        .map { |path, ext| Pathname.new(File.join(path, "#{cmd}#{ext}")) }
+        .reject { |path| path.directory? || !path.executable? }
+        .find { |exe_path| !exe_path.directory? && exe_path.executable? }
+    end
+  end
+end

--- a/lib/ruby_git/git_binary.rb
+++ b/lib/ruby_git/git_binary.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module RubyGit
+  # Sets and tracks the path to a git executable and reports the version
+  #
+  # @api public
+  #
+  class GitBinary
+    # Return a new GitBinary object
+    #
+    # @example
+    #   GitBinary.new
+    #
+    def initialize
+      @path = nil
+    end
+
+    # Sets the path to the git binary
+    #
+    # The given path must point to an executable file or a RuntimeError is raised.
+    #
+    # @example Setting the path to the git binary
+    #   git.path = '/usr/local/bin/git'
+    #
+    # @param [String] path the path to a git executable
+    #
+    # @return [Pathname]
+    #
+    # @raise [RuntimeError] A RuntimeError is raised when the path is not to an
+    #   existing executable file.
+    #
+    def path=(path)
+      new_path = Pathname.new(path)
+      raise "'#{new_path}' does not exist." unless new_path.exist?
+      raise "'#{new_path}' is not a file." unless new_path.file?
+      raise "'#{new_path}' is not executable." unless new_path.executable?
+
+      @path = new_path
+    end
+
+    # Retrieve the path to the git binary
+    #
+    # @example Get the git found on the PATH
+    #   git = RubyGit::GitBinary.new
+    #   path = git.path
+    #
+    # @return [Pathname] the path to the git binary
+    #
+    # @raise [RuntimeError] if path was not set via `path=` and either PATH is not set
+    #   or git was not found on the path.
+    #
+    def path
+      @path || (@path = self.class.default_path)
+    end
+
+    # Get the default path to to a git binary by searching the PATH
+    #
+    # @example Find the pathname to `super_git`
+    #   git = RubyGit::GitBinary.new
+    #   git.path = git.default_path(basename: 'super_git')
+    #
+    # @param [String] basename The basename of the git command
+    #
+    # @return [Pathname] the path to the git binary found in the path
+    #
+    # @raise [RuntimeError] if either PATH is not set or an executable file
+    #   basename was not found on the path.
+    #
+    def self.default_path(basename: 'git')
+      RubyGit::FileHelpers.which(basename) || raise("Could not find '#{basename}' in the PATH.")
+    end
+
+    # The version of git referred to by the path
+    #
+    # @example for version 2.28.0
+    #   git = RubyGit::GitBinary.new
+    #   puts git.version #=> [2,28,0]
+    #
+    # @return [Array<Integer>] an array of integers representing the version.
+    #
+    # @raise [RuntimeError] if path was not set via `path=` and either PATH is not set
+    #   or git was not found on the path.
+    #
+    def version
+      output = `#{path} --version`
+      version = output[/\d+\.\d+(\.\d+)+/]
+      version.split('.').collect(&:to_i)
+    end
+  end
+end

--- a/lib/ruby_git/version.rb
+++ b/lib/ruby_git/version.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 module RubyGit
+  # The ruby_git gem version
+  #
   VERSION = '0.1.1'
 end

--- a/spec/lib/ruby_git/git_binary_spec.rb
+++ b/spec/lib/ruby_git/git_binary_spec.rb
@@ -1,0 +1,333 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+
+RSpec.describe RubyGit::GitBinary do
+  let(:git_binary) { described_class.new }
+
+  describe '.default_path' do
+    context 'with no basename' do
+      subject { described_class.default_path }
+      let(:dir) { Dir.mktmpdir }
+      after { FileUtils.rm_rf dir }
+
+      context "when 'git' is not in the path" do
+        it 'should raise a RuntimeError' do
+          saved_env = ENV.to_hash
+          begin
+            ENV.replace({ 'PATH' => dir })
+            expect { subject }.to raise_error(RuntimeError)
+          ensure
+            ENV.replace(saved_env)
+          end
+        end
+      end
+
+      context "when 'git' is in the path" do
+        it 'should return a Pathname to the the first executable file in the PATH whose basename is git' do
+          saved_env = ENV.to_hash
+          begin
+            ENV.replace({ 'PATH' => dir })
+            path = Pathname.new(File.join(dir, 'git'))
+            FileUtils.touch(path)
+            path.chmod(0o755)
+
+            expect(subject).to be_kind_of(Pathname)
+            expect(subject).to eq(path)
+          ensure
+            ENV.replace(saved_env)
+          end
+        end
+      end
+    end
+
+    context "with basename 'mygit'" do
+      basename = 'mygit'
+      subject { described_class.default_path(basename: basename) }
+
+      context "and '#{basename}' is not in the PATH and 'git' is in the PATH" do
+        it 'should raise a RuntimeError' do
+          Dir.mktmpdir do |dir|
+            saved_env = ENV.to_hash
+            begin
+              ENV.replace({ 'PATH' => dir })
+
+              path = Pathname.new(File.join(dir, 'git'))
+              FileUtils.touch(path)
+              path.chmod(0o755)
+              expect { subject }.to raise_error(RuntimeError)
+            ensure
+              ENV.replace(saved_env)
+            end
+          end
+        end
+      end
+
+      context "and '#{basename}' is in the PATH but not a file" do
+        it 'should raise a RuntimeError' do
+          Dir.mktmpdir do |dir|
+            saved_env = ENV.to_hash
+            begin
+              ENV.replace({ 'PATH' => dir })
+              path = Pathname.new(File.join(dir, basename))
+              FileUtils.mkdir(path)
+              path.chmod(0o755)
+              expect { subject }.to raise_error(RuntimeError)
+            ensure
+              ENV.replace(saved_env)
+            end
+          end
+        end
+      end
+
+      context "and '#{basename}' is in the PATH but not executable file" do
+        it 'should raise a RuntimeError' do
+          Dir.mktmpdir do |dir|
+            saved_env = ENV.to_hash
+            begin
+              ENV.replace({ 'PATH' => dir })
+              path = Pathname.new(File.join(dir, basename))
+              FileUtils.mkdir(path)
+              path.chmod(0o666)
+              expect { subject }.to raise_error(RuntimeError)
+            ensure
+              ENV.replace(saved_env)
+            end
+          end
+        end
+      end
+
+      context "and PATHEXT is '.exe;.com'" do
+        context "and '#{basename}.com' is an executable file in the path" do
+          it 'should not raise a RuntimeError' do
+            Dir.mktmpdir do |dir|
+              saved_env = ENV.to_hash
+              begin
+                ENV.replace({ 'PATH' => dir, 'PATHEXT' => '.com;.exe' })
+                path = Pathname.new(File.join(dir, "#{basename}.com"))
+                FileUtils.touch(path)
+                path.chmod(0o755)
+                expect { subject }.not_to raise_error
+              ensure
+                ENV.replace(saved_env)
+              end
+            end
+          end
+        end
+
+        context "and '#{basename}.exe' is an executable file in the path" do
+          it 'should not raise a RuntimeError' do
+            Dir.mktmpdir do |dir|
+              saved_env = ENV.to_hash
+              begin
+                ENV.replace({ 'PATH' => dir, 'PATHEXT' => '.com;.exe' })
+                path = Pathname.new(File.join(dir, "#{basename}.exe"))
+                FileUtils.touch(path)
+                path.chmod(0o755)
+                expect { subject }.not_to raise_error
+              ensure
+                ENV.replace(saved_env)
+              end
+            end
+          end
+        end
+
+        context "when neither '#{basename}.com' or '#{basename}.exe' are an executable file in the path" do
+          it 'should raise a RuntimeError' do
+            Dir.mktmpdir do |dir|
+              saved_env = ENV.to_hash
+              begin
+                ENV.replace({ 'PATH' => dir, 'PATHEXT' => '.com;.exe' })
+                path = Pathname.new(File.join(dir, 'git.fubar'))
+                FileUtils.touch(path)
+                path.chmod(0o755)
+                expect { subject }.to raise_error(RuntimeError)
+              ensure
+                ENV.replace(saved_env)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe '#path=' do
+    subject { described_class.new.path = new_path }
+    let(:dir) { Dir.mktmpdir }
+    after { FileUtils.rm_rf dir }
+
+    context 'when given a path that is not convertable to a string' do
+      let(:new_path) { 1 }
+      it 'should raise a TypeError' do
+        expect { subject }.to raise_error(TypeError)
+      end
+    end
+
+    context 'when given a path that does not exist' do
+      let(:new_path) { Pathname.new(File.join(dir, 'git')) }
+      it 'should raise a RuntimeError' do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when set to a path that is not a file' do
+      let(:new_path) { Pathname.new(File.join(dir, 'git')) }
+      it 'should raise a RuntimeError' do
+        Dir.mktmpdir do |_dir|
+          FileUtils.mkdir(new_path)
+          expect { subject }.to raise_error(RuntimeError)
+        end
+      end
+    end
+
+    context 'when set to a path that is not an executable file' do
+      let(:new_path) { Pathname.new(File.join(dir, 'git')) }
+      it 'should raise a RuntimeError' do
+        Dir.mktmpdir do |_dir|
+          FileUtils.touch(new_path)
+          new_path.chmod(0o644)
+          expect { subject }.to raise_error(RuntimeError)
+        end
+      end
+    end
+
+    context 'when set to a path that is an executable file' do
+      let(:new_path) { Pathname.new(File.join(dir, 'git')) }
+      it 'should return the path' do
+        Dir.mktmpdir do |_dir|
+          FileUtils.touch(new_path)
+          new_path.chmod(0o755)
+          expect { subject }.not_to raise_error
+          expect(subject).to eq(new_path)
+        end
+      end
+    end
+
+    context 'when path is given as a string' do
+      let(:new_path) { Pathname.new(File.join(dir, 'git')) }
+      it 'should return a Pathname' do
+        Dir.mktmpdir do |_dir|
+          FileUtils.touch(new_path)
+          FileUtils.chmod(0o755, new_path)
+          expect { subject }.not_to raise_error
+          expect(subject).to eq(new_path)
+          expect(subject).to be_kind_of(Pathname)
+        end
+      end
+    end
+
+    context 'when set to a path that is a symlink to an executable file' do
+      let(:new_path) { Pathname.new(File.join(dir, 'symlink_to_git')) }
+      it 'should not raise an error' do
+        Dir.mktmpdir do |dir|
+          actual_path = Pathname.new(File.join(dir, 'git'))
+          FileUtils.touch(actual_path)
+          actual_path.chmod(0o755)
+          FileUtils.ln_s(actual_path, new_path)
+          expect { subject }.not_to raise_error
+          expect(subject).to eq(new_path)
+        end
+      end
+    end
+  end
+
+  describe '#path' do
+    let(:git_binary) { described_class.new }
+    subject { git_binary.path }
+    let(:dir) { Dir.mktmpdir }
+    after { FileUtils.rm_rf dir }
+
+    context 'when path was not set' do
+      context 'and git is in the PATH' do
+        it 'should find the git in the PATH' do
+          saved_env = ENV.to_hash
+          begin
+            ENV.replace({ 'PATH' => dir })
+            path = Pathname.new(File.join(dir, 'git'))
+            FileUtils.touch(path)
+            FileUtils.chmod(0o755, path)
+            expect(subject).to be_kind_of(Pathname)
+            expect(subject).to eq(path)
+          ensure
+            ENV.replace(saved_env)
+          end
+        end
+      end
+
+      context 'and git is not in the PATH' do
+        it 'should raise a RuntimeError' do
+          saved_env = ENV.to_hash
+          begin
+            ENV.replace({ 'PATH' => dir })
+            expect { subject }.to raise_error(RuntimeError)
+          ensure
+            ENV.replace(saved_env)
+          end
+        end
+      end
+    end
+
+    context 'when path was set' do
+      let(:new_path) { Pathname.new(File.join(dir, 'mygit')) }
+      before do
+        FileUtils.touch(new_path)
+        FileUtils.chmod(0o755, new_path)
+        git_binary.path = new_path
+      end
+      it 'should return what path was set to' do
+        expect(subject).to eq(new_path)
+      end
+    end
+
+    context 'when path has been set to a file not in the PATH' do
+      context 'and a different git exists in the PATH' do
+        it 'should return what path was originally set to' do
+          directory_in_path = File.join(dir, 'dir1')
+          FileUtils.mkdir(directory_in_path)
+          git_in_path = Pathname.new(File.join(directory_in_path, 'git'))
+          FileUtils.touch(git_in_path)
+          FileUtils.chmod(0o755, git_in_path)
+
+          directory_not_in_path = File.join(dir, 'dir2')
+          FileUtils.mkdir(directory_not_in_path)
+          git_not_in_path = Pathname.new(File.join(directory_not_in_path, 'git'))
+          FileUtils.touch(git_not_in_path)
+          FileUtils.chmod(0o755, git_not_in_path)
+
+          saved_env = ENV.to_hash
+          begin
+            ENV.replace({ 'PATH' => directory_in_path })
+            git_binary.path = git_not_in_path
+
+            expect(subject).to eq(git_not_in_path)
+          ensure
+            ENV.replace(saved_env)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#version' do
+    subject { git_binary.version }
+    let(:dir) { Dir.mktmpdir }
+    after { FileUtils.rm_rf dir }
+    it 'should return the version returned from --version' do
+      saved_env = ENV.to_hash
+      begin
+        ENV.replace({ 'PATH' => "#{dir}:#{ENV['PATH']}" })
+        path = Pathname.new(File.join(dir, 'git'))
+        File.write(path, <<~SCRIPT)
+          #!/usr/bin/env sh
+          if [ "$1" != '--version' ]; then echo '--version required'; exit 1; fi
+          echo 'git version 10.11.12'
+        SCRIPT
+        FileUtils.chmod(0o755, path)
+        expect(subject).to eq([10, 11, 12])
+      ensure
+        ENV.replace(saved_env)
+      end
+    end
+  end
+end

--- a/spec/lib/ruby_git_spec.rb
+++ b/spec/lib/ruby_git_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+
+RSpec.describe RubyGit do
+  it 'should have a version number' do
+    expect(RubyGit::VERSION).not_to be nil
+  end
+
+  describe '.git_binary' do
+    subject { described_class.git }
+    it { is_expected.to be_kind_of(RubyGit::GitBinary) }
+  end
+end

--- a/spec/ruby_git_spec.rb
+++ b/spec/ruby_git_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe RubyGit do
-  it 'has a version number' do
-    expect(RubyGit::VERSION).not_to be nil
-  end
-end


### PR DESCRIPTION
### Description
Add the ability to set and retrieve the path to the git binary used by this library.

### What is changed?
Added `RubyGit.git` method and the `RubyGit::GitBinary` class.

### What else was changed and why?
Added `RubyGit::FileHelpers` module for the `which` implementation. `which` is a platform independent implementation of the Linux `which` command.