### PR TITLE
Add Gem badge and correct home page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **THIS PROJECT IS A WORK IN PROGRESS AND IS NOT USEFUL IN ITS CURRENT STATE**
 
+[![Gem Version](https://badge.fury.io/rb/ruby_git.svg)](https://badge.fury.io/rb/ruby_git)
 [![Build Status](https://travis-ci.org/jcouball/ruby_git.svg?branch=main)](https://travis-ci.org/jcouball/ruby_git)
 [![Maintainability](https://api.codeclimate.com/v1/badges/2d8d52a55d655b6a3def/maintainability)](https://codeclimate.com/github/jcouball/ruby_git/maintainability)
 

--- a/ruby_git.gemspec
+++ b/ruby_git.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     An object-oriented interface to working with Git Worktrees and Repositories that
     tries to make sense out of the Git command line.
   DESCRIPTION
-  spec.homepage = 'https://github.com/pages/jcouball/ruby_git/'
+  spec.homepage = 'https://github.com/jcouball/ruby_git/'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
   spec.requirements = [
     'Git 2.18.0 or later',


### PR DESCRIPTION
### Description
* Add Gem badge to the README.md so that people can see the latest version.
* Correct the homepage URL in the gemspec so it is right on rubygems.org

### What is changed?
README.md and ruby_git.gemspec

### What else was changed and why?
Nothing.