### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Defines who must review pull requests.
+
+* @jcouball


### PR DESCRIPTION
### Description
Define who must review pull requests.

### What is changed?
The CODEOWNERS file was added. This file defines the individuals or teams that are responsible for code in a repository.

Code owners are automatically requested for review when someone opens a pull request that modifies code that they own.

See the GitHub documentation [About code owners](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners) for more details.

### What else was changed and why?
Nothing.