### PR TITLE
Move the ruby_git repository to the main-branch GitHub organization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,45 +1,45 @@
 # Change Log
 
-## [v0.1.3](https://github.com/jcouball/ruby_git/releases/tag/v0.1.3) (2020-09-24)
+## [v0.1.3](https://github.com/main-branch/ruby_git/releases/tag/v0.1.3) (2020-09-24)
 
-[Full Changelog](https://github.com/jcouball/ruby_git/compare/v0.1.2...v0.1.3)
-
-**Merged pull requests:**
-
-- Add Gem badge and correct home page URL [\#10](https://github.com/jcouball/ruby_git/pull/10) ([jcouball](https://github.com/jcouball))
-
-## [v0.1.2](https://github.com/jcouball/ruby_git/releases/tag/v0.1.2) (2020-09-24)
-
-[Full Changelog](https://github.com/jcouball/ruby_git/compare/0.1.2...v0.1.2)
+[Full Changelog](https://github.com/main-branch/ruby_git/compare/v0.1.2...v0.1.3)
 
 **Merged pull requests:**
 
-- Release v0.1.2 [\#9](https://github.com/jcouball/ruby_git/pull/9) ([jcouball](https://github.com/jcouball))
+- Add Gem badge and correct home page URL [\#10](https://github.com/main-branch/ruby_git/pull/10) ([jcouball](https://github.com/jcouball))
 
-## [0.1.2](https://github.com/jcouball/ruby_git/releases/tag/0.1.2) (2020-09-24)
+## [v0.1.2](https://github.com/main-branch/ruby_git/releases/tag/v0.1.2) (2020-09-24)
 
-[Full Changelog](https://github.com/jcouball/ruby_git/compare/v0.1.1...0.1.2)
-
-**Merged pull requests:**
-
-- Update instructions for creating releases and updating the changelog [\#8](https://github.com/jcouball/ruby_git/pull/8) ([jcouball](https://github.com/jcouball))
-- Changes requested in documentation review [\#7](https://github.com/jcouball/ruby_git/pull/7) ([jcouball](https://github.com/jcouball))
-- Set and retrieve the path to the git binary used by this library [\#6](https://github.com/jcouball/ruby_git/pull/6) ([jcouball](https://github.com/jcouball))
-- Move RSpec config from Rakefile to .rspec [\#5](https://github.com/jcouball/ruby_git/pull/5) ([jcouball](https://github.com/jcouball))
-- Release v0.1.1 [\#4](https://github.com/jcouball/ruby_git/pull/4) ([jcouball](https://github.com/jcouball))
-
-## [v0.1.1](https://github.com/jcouball/ruby_git/releases/tag/v0.1.1) (2020-09-18)
-
-[Full Changelog](https://github.com/jcouball/ruby_git/compare/v0.1.0...v0.1.1)
+[Full Changelog](https://github.com/main-branch/ruby_git/compare/0.1.2...v0.1.2)
 
 **Merged pull requests:**
 
-- Add notice saying that this project is a work in progress [\#3](https://github.com/jcouball/ruby_git/pull/3) ([jcouball](https://github.com/jcouball))
-- Remove Gemfile.lock and add it to .gitignore [\#2](https://github.com/jcouball/ruby_git/pull/2) ([jcouball](https://github.com/jcouball))
+- Release v0.1.2 [\#9](https://github.com/main-branch/ruby_git/pull/9) ([jcouball](https://github.com/jcouball))
 
-## [v0.1.0](https://github.com/jcouball/ruby_git/releases/tag/v0.1.0) (2020-09-18)
+## [0.1.2](https://github.com/main-branch/ruby_git/releases/tag/0.1.2) (2020-09-24)
 
-[Full Changelog](https://github.com/jcouball/ruby_git/compare/04b4b2bc59b0b09ad45a69572450cb393dbe79a1...v0.1.0)
+[Full Changelog](https://github.com/main-branch/ruby_git/compare/v0.1.1...0.1.2)
+
+**Merged pull requests:**
+
+- Update instructions for creating releases and updating the changelog [\#8](https://github.com/main-branch/ruby_git/pull/8) ([jcouball](https://github.com/jcouball))
+- Changes requested in documentation review [\#7](https://github.com/main-branch/ruby_git/pull/7) ([jcouball](https://github.com/jcouball))
+- Set and retrieve the path to the git binary used by this library [\#6](https://github.com/main-branch/ruby_git/pull/6) ([jcouball](https://github.com/jcouball))
+- Move RSpec config from Rakefile to .rspec [\#5](https://github.com/main-branch/ruby_git/pull/5) ([jcouball](https://github.com/jcouball))
+- Release v0.1.1 [\#4](https://github.com/main-branch/ruby_git/pull/4) ([jcouball](https://github.com/jcouball))
+
+## [v0.1.1](https://github.com/main-branch/ruby_git/releases/tag/v0.1.1) (2020-09-18)
+
+[Full Changelog](https://github.com/main-branch/ruby_git/compare/v0.1.0...v0.1.1)
+
+**Merged pull requests:**
+
+- Add notice saying that this project is a work in progress [\#3](https://github.com/main-branch/ruby_git/pull/3) ([jcouball](https://github.com/jcouball))
+- Remove Gemfile.lock and add it to .gitignore [\#2](https://github.com/main-branch/ruby_git/pull/2) ([jcouball](https://github.com/jcouball))
+
+## [v0.1.0](https://github.com/main-branch/ruby_git/releases/tag/v0.1.0) (2020-09-18)
+
+[Full Changelog](https://github.com/main-branch/ruby_git/compare/04b4b2bc59b0b09ad45a69572450cb393dbe79a1...v0.1.0)
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ You can contribute in two ways:
 ruby_git utilizes [GitHub Issues](https://help.github.com/en/github/managing-your-work-on-github/about-issues)
 for issue tracking and feature requests.
 
-Report an issue or feature request by [creating a ruby_git Github issue](https://github.com/jcouball/ruby_git/issues/new).
+Report an issue or feature request by [creating a ruby_git Github issue](https://github.com/main-branch/ruby_git/issues/new).
 Fill in the template to describe the issue or feature request the best you can.
 
 ## How to submit a code or documentation change
@@ -84,7 +84,7 @@ All pull requests must meet these requirements:
   * The documentation suite must maintain 100% documentation to pass
 
 ### Continuous Integration
-  * All tests must pass in the project's [Travis CI](https://travis-ci.org/jcouball/ruby_git)
+  * All tests must pass in the project's [Travis CI](https://travis-ci.org/main-branch/ruby_git)
     build before the pull request will be merged.
   * You can simulate what happens in the Travis CI build by running `bundle exec rake` in 
     the projects root directory.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 **THIS PROJECT IS A WORK IN PROGRESS AND IS NOT USEFUL IN ITS CURRENT STATE**
 
 [![Gem Version](https://badge.fury.io/rb/ruby_git.svg)](https://badge.fury.io/rb/ruby_git)
-[![Build Status](https://travis-ci.org/jcouball/ruby_git.svg?branch=main)](https://travis-ci.org/jcouball/ruby_git)
-[![Maintainability](https://api.codeclimate.com/v1/badges/2d8d52a55d655b6a3def/maintainability)](https://codeclimate.com/github/jcouball/ruby_git/maintainability)
+[![Build Status](https://travis-ci.org/main-branch/ruby_git.svg?branch=main)](https://travis-ci.org/main-branch/ruby_git)
+[![Maintainability](https://api.codeclimate.com/v1/badges/5403e4613b7518f70da7/maintainability)](https://codeclimate.com/github/main-branch/ruby_git/maintainability)
 
 RubyGit is an object-oriented wrapper for the `git` command line tool for working with Worktrees
 and Repositories. It tries to make more sense out of the Git command line. See the object model
@@ -65,7 +65,7 @@ To tell what version of Git is being used:
 puts RubyGit.git_version
 ```
 
-The full API is documented in [the RubyGit YARD documentation](https://github.com/pages/jcouball/ruby_git).
+The full API is documented in [the RubyGit YARD documentation](https://github.com/pages/main-branch/ruby_git).
 
 ## Development
 
@@ -77,4 +77,4 @@ automatically requires ruby_git.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/jcouball/ruby_git.
+Bug reports and pull requests are welcome on GitHub at https://github.com/main-branch/ruby_git.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,7 +33,7 @@ version number and (2) update the CHANGELOG.md, and (3) tag the release.
 
 ## Create a GitHub release
 
-On [the ruby_git releases page](https://github.com/jcouball/ruby_git/releases),
+On [the ruby_git releases page](https://github.com/main-branch/ruby_git/releases),
 select `Draft a new release`
 
   * Select the tag corresponding to the version being released `v1.1.0.pre1`
@@ -45,7 +45,7 @@ select `Draft a new release`
 
 ## Build and release the gem
 
-Clone [jcouball/ruby_git](https://github.com/jcouball/ruby_git) directly (not a
+Clone [main-branch/ruby_git](https://github.com/main-branch/ruby_git) directly (not a
 fork) and ensure your local working copy is on the main branch
 
   * Verify that you are not on a fork with the command `git remote -v`

--- a/Rakefile
+++ b/Rakefile
@@ -70,9 +70,9 @@ require 'github_changelog_generator/task'
 
 GitHubChangelogGenerator::RakeTask.new :changelog do |config|
   config.header = '# Change Log'
-  config.user = 'jcouball'
+  config.user = 'main-branch'
   config.project = 'ruby_git'
   config.future_release = "v#{RubyGit::VERSION}"
-  config.release_url = 'https://github.com/jcouball/ruby_git/releases/tag/%s'
+  config.release_url = 'https://github.com/main-branch/ruby_git/releases/tag/%s'
   config.author = true
 end

--- a/ruby_git.gemspec
+++ b/ruby_git.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
     An object-oriented interface to working with Git Worktrees and Repositories that
     tries to make sense out of the Git command line.
   DESCRIPTION
-  spec.homepage = 'https://github.com/jcouball/ruby_git/'
+  spec.homepage = 'https://github.com/main-branch/ruby_git/'
   spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
   spec.requirements = [
     'Git 2.18.0 or later',
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/jcouball/ruby_git/'
-  spec.metadata['changelog_uri'] = 'https://github.com/jcouball/ruby_git/blob/main/CHANGELOG.md'
+  spec.metadata['source_code_uri'] = 'https://github.com/main-branch/ruby_git/'
+  spec.metadata['changelog_uri'] = 'https://github.com/main-branch/ruby_git/blob/main/CHANGELOG.md'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
### Description
The repo for `ruby_git` was moved from my personal space in GitHub to the `main-branch` organization.

### What is changed?
URLs and various other things across multiple files.

### What else was changed and why?
Nothing.