### PR TITLE
Allow @main-branch/ruby_git-codeowners to approve Pull Requests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # Defines who must review pull requests.
+# See https://help.github.com/articles/about-codeowners/ for details.
 
-* @jcouball
+* @jcouball @main-branch/ruby_git-codeowners

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ Follow the instructions in the pull request template.
 
 Code review takes place in a GitHub pull request using the [the Github pull request review feature](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews).
 
-Once your pull request is ready for review, request a review from at least one
-[maintainer](MAINTAINERS.md) and any number of other contributors.
+Once your pull request is ready for review, request a review from at least one of the
+[code owners](https://github.com/orgs/main-branch/teams/ruby_git-codeowners/members).
 
 During the review process, you may need to make additional commits which would
 need to be squashed.  It may also be necessary to rebase to main again if other

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,0 @@
-# Maintainers
-
-When making changes in this repository, one of the maintainers below must review
-and approve your pull request.
-
-### Maintainers
-
-* [James Couball](https://github.com/jcouball)


### PR DESCRIPTION
### Description
Allow @main-branch/ruby_git-codeowners to approve Pull Requests

### What is changed?
* Added @main-branch/ruby_git-codeowners to the CODEOWNERS file
* Updated contributing that members of @main-branch/ruby_git-codeowners must approve pull requests

### What else was changed and why?
Nothing