### PR TITLE
Add centralized logging to the RubyGit gem

### DIFF
--- a/lib/ruby_git.rb
+++ b/lib/ruby_git.rb
@@ -6,6 +6,8 @@ require 'ruby_git/git_binary'
 require 'ruby_git/version'
 require 'ruby_git/worktree'
 
+require 'null_logger'
+
 # RubyGit is an object-oriented wrapper for the `git` command line tool for
 # working with Worktrees and Repositories. It tries to make more sense out
 # of the Git command line.
@@ -13,18 +15,44 @@ require 'ruby_git/worktree'
 # @api public
 #
 module RubyGit
-  # Return information about the git binary used by this library
-  #
-  # Use this object to set the path to the git binary to use or to see the
-  # path being used.
-  #
-  # @example Setting the git binary path
-  #    RubyGit.git.path = '/usr/local/bin/git'
-  #
-  # @return [RubyGit::GitBinary]
-  #
-  def self.git
-    (@git ||= RubyGit::GitBinary.new)
+  @git = RubyGit::GitBinary.new
+
+  class << self
+    # Information about the git binary used by the RubyGit gem
+    #
+    # Use this object to set the path to the git binary to use or to see the
+    # path being used.
+    #
+    # @example Setting the git binary path
+    #   RubyGit.git.path = '/usr/local/bin/git'
+    #
+    # @return [RubyGit::GitBinary] the git binary object
+    #
+    attr_reader :git
+  end
+
+  @logger = NullLogger.new
+
+  class << self
+    # The logger used by the RubyGit gem
+    #
+    # The default value is a NullLogger
+    #
+    # @example Using the logger
+    #   RubyGit.logger.debug('Debug message')
+    #
+    # @example Setting the logger
+    #   require 'logger'
+    #   require 'stringio'
+    #   log_device = StringIO.new
+    #   RubyGit.logger = Logger.new(log_device, level: Logger::DEBUG)
+    #   RubyGit.logger.debug('Debug message')
+    #   log_device.string.include?('Debug message')
+    #    => true
+    #
+    # @return [Logger] the logger used by the RubyGit gem
+    #
+    attr_accessor :logger
   end
 
   # Create an empty Git repository under the root worktree `path`

--- a/lib/ruby_git/worktree.rb
+++ b/lib/ruby_git/worktree.rb
@@ -115,6 +115,7 @@ module RubyGit
       raise RubyGit::Error, "Path '#{worktree_path}' not valid." unless File.directory?(worktree_path)
 
       @path = root_path(worktree_path)
+      RubyGit.logger.debug("Created #{inspect}")
     end
 
     # Find the root path of a worktree containing `path`

--- a/ruby_git.gemspec
+++ b/ruby_git.gemspec
@@ -40,6 +40,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'null-logger', '~> 0.1'
+
   spec.add_development_dependency 'bump', '~> 0.9'
   spec.add_development_dependency 'bundler-audit', '~> 0.7'
   spec.add_development_dependency 'github_changelog_generator', '~> 1.15'

--- a/spec/lib/ruby_git/worktree_initialize_spec.rb
+++ b/spec/lib/ruby_git/worktree_initialize_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'logger'
+require 'stringio'
+require 'tmpdir'
+
+RSpec.describe RubyGit::Worktree do
+  describe '.initialize' do
+    subject { described_class.open(worktree_path) }
+    let(:tmpdir) { Dir.mktmpdir }
+    after { FileUtils.rm_rf(tmpdir) if File.exist?(tmpdir) }
+
+    context 'with a valid worktree path' do
+      let(:worktree_path) { tmpdir }
+      before do
+        raise RuntimeError unless system('git init', chdir: worktree_path, %i[out err] => IO::NULL)
+      end
+      it 'should log that a Worktree object was created at debug level' do
+        log_device = StringIO.new
+        saved_logger = RubyGit.logger
+        RubyGit.logger = Logger.new(log_device, level: Logger::DEBUG)
+        RubyGit::Worktree.new(worktree_path)
+        RubyGit.logger = saved_logger
+        expect(log_device.string).to include(' : Created #<RubyGit::Worktree:')
+      end
+    end
+  end
+end

--- a/spec/lib/ruby_git_spec.rb
+++ b/spec/lib/ruby_git_spec.rb
@@ -1,10 +1,25 @@
 # frozen_string_literal: true
 
 require 'tmpdir'
+require 'logger'
 
 RSpec.describe RubyGit do
   it 'should have a version number' do
     expect(RubyGit::VERSION).not_to be nil
+  end
+
+  describe '.logger' do
+    subject { described_class.logger }
+
+    context 'when a logger has not be set' do
+      it { is_expected.to be_kind_of(NullLogger) }
+    end
+
+    context 'when a logger has been set' do
+      let(:logger) { Logger.new($stdout, level: Logger::DEBUG) }
+      before { RubyGit.logger = logger }
+      it { is_expected.to eq(logger) }
+    end
   end
 
   describe '.git_binary' do


### PR DESCRIPTION
### Description
As a user of the RubyGit gem
I want to be able to see what git commands are executed as I use the RubyGit gem
So that I can debug my use of the RubyGit gem

Add a centralized logger as an attribute to the `RubyGit` module.

Using the logger:
```ruby
RubyGit.logger.debug('Debug message')
```

Setting the logger to capture log messages in an instance of `StringIO`:
```ruby
require 'logger'
require 'stringio'
log_device = StringIO.new
RubyGit.logger = Logger.new(log_device, level: Logger::DEBUG)
RubyGit.logger.debug('Debug message')
log_device.string.include?('Debug message')
 => true
```

By default, `RubyGit.logger` should be an instance of `NullLogger`.

### What is changed?
`ruby_git.gemspec`
* Add runtime dependency on 'null-logger'

`lib/ruby_git.rb` and `lib/ruby_git_spec.rb`
* Add the module attribute `logger` which defaults to an instance of `NullLogger`.
* Change how `RubyGit.git` is documented so it shows up as a "Class Attribute" in the yard documentation to match how `RubyGit.logger` is documented.

`lib/ruby_git/worktree.rb` and `lib/ruby_git/worktree_spec_initialize`
* Log creation of `Worktree` instances at debug level.

### What else was changed and why?
* Nothing