### PR TITLE
Remove MAINTAINERS.md from yard documentation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -2,4 +2,4 @@
 --hide-void-return
 --markup-provider=redcarpet
 --markup markdown
-- CHANGELOG.md CONTRIBUTING.md MAINTAINERS.md RELEASING.md LICENSE.md
+- CHANGELOG.md CONTRIBUTING.md RELEASING.md LICENSE.md


### PR DESCRIPTION
### Description
Remove `MAINTAINERS.md` from the yard documentation.  `MAINTAINER.md` was removed from the project in #19.

### What is changed?
`.yardopts`
* Removed reference to `MAINTAINERS.md`

### What else was changed and why?
Nothing