### PR TITLE
Upgrade to Rubocop 1.0

### DIFF
--- a/ruby_git.gemspec
+++ b/ruby_git.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'redcarpet', '~> 3.5'
   spec.add_development_dependency 'rspec', '~> 3.9'
-  spec.add_development_dependency 'rubocop', '~> 0.91'
+  spec.add_development_dependency 'rubocop', '~> 1.0'
   spec.add_development_dependency 'simplecov', '0.17.1'
   spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'yardstick', '~> 0.9'


### PR DESCRIPTION
### Description
Rubocop 1.0 was released.  Upgrade dependency to use 1.x.

### What is changed?
Just the gemspec.

### What else was changed and why?
Nothing.