### PR TITLE
Create a Github CI action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,27 @@
+# Download a prebuilt Ruby version, install dependencies, and run the default Rake task
+
+name: Ruby
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        
+      - name: Setup Ruby
+        uses: uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6 # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Run rake
+        run: bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Setup Ruby
-        uses: uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6 # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
### Description
Sometimes Travis CI takes a hour just to start the build. This is because their open source builds are quite limited.  Experiment with GitHub Actions for CI build to see if they provide faster feedback.

### What is changed?
* the build is defined `.github/workflows/ruby.yml`

### What else was changed and why?
Nothing