### PR TITLE
Do not enforce coverage threshold for RSpec dry run

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,10 +19,12 @@ SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 SimpleCov.start
 
 SimpleCov.at_exit do
-  SimpleCov.result.format!
-  if SimpleCov.result.covered_percent < 100
-    warn 'FAIL: RSpec Test coverage fell below 100%'
-    exit 1
+  unless RSpec.configuration.dry_run?
+    SimpleCov.result.format!
+    if SimpleCov.result.covered_percent < 100
+      warn 'FAIL: RSpec Test coverage fell below 100%'
+      exit 1
+    end
   end
 end
 


### PR DESCRIPTION
### Description
Changes to support using Visual Studio Code / [GitHub Codespaces](https://github.com/features/codespaces)

### What is changed?
* The Visual Studio Code Rspec Test Explorer extension runs `rspec --dry-run` in order to list the available tests.  In this PR, a change was made to `spec/spec_helper.rb` to NOT make an RSpec dry run fail when code coverage is lower than the configured amount.

### What else was changed and why?
* Nothing