### PR TITLE
Update continuous integration and experimental ruby builds

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: Continuous Integration
 
 on:
   push:
@@ -7,22 +7,29 @@ on:
   pull_request:
     branches: [main]
 
+  workflow_dispatch:
+
+# Supported platforms / Ruby versions:
+#  - Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
+#  - Windows: MRI (3.1), JRuby (9.4)
+
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+
     runs-on: ${{ matrix.operating-system }}
-    continue-on-error: ${{ matrix.experimental == 'Yes' }}
+    continue-on-error: true
 
     strategy:
+      fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", head]
+        ruby: ["3.1", "3.2", "3.3", "jruby-9.4", "truffleruby-24"]
         operating-system: [ubuntu-latest]
-        # experimental: [No]
-        # include:
-        #   - ruby: "3.1"
-        #     operating-system: windows-latest
-        #   - ruby: head
-        #     operating-system: ubuntu-latest
+        include:
+          - ruby: "3.1"
+            operating-system: windows-latest
+          - ruby: "jruby-9.4"
+            operating-system: windows-latest
 
     steps:
       - name: Checkout
@@ -38,10 +45,10 @@ jobs:
         run: bundle exec rake
 
   coverage:
+    name: Report test coverage to CodeClimate
+
     needs: [build]
     runs-on: ubuntu-latest
-
-    name: Report test coverage to CodeClimate
 
     steps:
       - name: Checkout
@@ -53,12 +60,10 @@ jobs:
           ruby-version: 3.1
           bundler-cache: true
 
-      - name: Run tests
-        run: bundle exec rake spec
-
       - name: Report test coverage
         uses: paambaati/codeclimate-action@v9
         env:
-          CC_TEST_REPORTER_ID: b86e77bc6980a43dc09314502fe13334e0f663770b840628ca0716e6dcdeeb5d
+          CC_TEST_REPORTER_ID: ddf1b66251c781daaf3d2b44371e7040ce4a60126bc0c270855f8bee2c58d6d1
         with:
+          coverageCommand: bundle exec rake spec
           coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -1,0 +1,46 @@
+name: Experimental Ruby Builds
+
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+
+# Experimental platforms / Ruby versions:
+#  - Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
+#  - Windows: MRI (head), JRuby (head)
+
+jobs:
+  build:
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+    
+    runs-on: ${{ matrix.operating-system }}
+    continue-on-error: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: head
+            operating-system: ubuntu-latest
+          - ruby: head
+            operating-system: windows-latest
+          - ruby: truffleruby-head
+            operating-system: ubuntu-latest
+          - ruby: jruby-head
+            operating-system: ubuntu-latest
+          - ruby: jruby-head
+            operating-system: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run rake
+        run: bundle exec rake

--- a/ruby_git.gemspec
+++ b/ruby_git.gemspec
@@ -19,10 +19,9 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/main-branch/ruby_git/'
   spec.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
   spec.requirements = [
-    'Git 2.28.0 or later',
-    'Ruby 3.1 or later',
-    'Only MRI Ruby and JRuby are officially supported.',
-    'Mac, Linux, Unix, and Windows platforms are supported'
+    'Platform: Mac, Linux, or Windows',
+    'Ruby: MRI 3.1 or later, TruffleRuby 24 or later, or JRuby 9.4 or later',
+    'Git 2.28.0 or later'
   ]
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
@@ -45,11 +44,17 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bump', '~> 0.10'
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'rake', '~> 13.2'
-  spec.add_development_dependency 'redcarpet', '~> 3.6'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rubocop', '~> 1.66'
   spec.add_development_dependency 'simplecov', '0.17'
-  spec.add_development_dependency 'yard', '~> 0.9'
-  spec.add_development_dependency 'yardstick', '~> 0.9'
+  spec.add_development_dependency 'simplecov-lcov', '0.8'
+  spec.add_development_dependency 'simplecov-rspec', '0.2'
+
+  unless RUBY_PLATFORM == 'java'
+    spec.add_development_dependency 'redcarpet', '~> 3.6'
+    spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
+    spec.add_development_dependency 'yardstick', '~> 0.9'
+  end
+
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'simplecov'
-
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
@@ -14,18 +12,18 @@ RSpec.configure do |config|
   end
 end
 
-# Setup simplecov
-SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
-SimpleCov.start
+# SimpleCov configuration
+#
+require 'simplecov'
+require 'simplecov-lcov'
 
-SimpleCov.at_exit do
-  unless RSpec.configuration.dry_run?
-    SimpleCov.result.format!
-    if SimpleCov.result.covered_percent < 100
-      warn 'FAIL: RSpec Test coverage fell below 100%'
-      exit 1
-    end
-  end
+if ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::LcovFormatter
+  ]
 end
+
+SimpleCov.start
 
 require 'ruby_git'


### PR DESCRIPTION
Update continuous integration and experimental Ruby builds making the following changes:

* Change supported platforms / Ruby versions
  * Continuous integration platforms / Ruby versions:
    * Ubuntu: MRI (3.1, 3.2, 3.3), TruffleRuby (24), JRuby (9.4)
    * Windows: MRI (3.1), JRuby (9.4)
  * Experimental platforms / Ruby versions:
    * Ubuntu: MRI (head), TruffleRuby (head), JRuby (head)
    * Windows: MRI (head), JRuby (head)

* Update continuous integration and experimental ruby builds to use the same workflow for all projects (including possibly renaming the workflow file name and name)

* Update the minimally required Ruby in the project’s gemspec and .rubocop.yml

* Update dependencies to latest

* Auto correct new Rubocop offenses