### PR TITLE
Reset CodeClimate code coverage reporter id

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Report test coverage
         uses: paambaati/codeclimate-action@v9
         env:
-          CC_TEST_REPORTER_ID: ddf1b66251c781daaf3d2b44371e7040ce4a60126bc0c270855f8bee2c58d6d1
+          CC_TEST_REPORTER_ID: b86e77bc6980a43dc09314502fe13334e0f663770b840628ca0716e6dcdeeb5d
         with:
           coverageCommand: bundle exec rake spec
           coverageLocations: ${{github.workspace}}/coverage/lcov/*.lcov:lcov


### PR DESCRIPTION
PR #35 copy and pasted the wrong code coverage reporter id for this project. This PR resets it back.