### PR TITLE
Integrate simplecov-rspec into the project

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -31,6 +31,9 @@ jobs:
           - ruby: "jruby-9.4"
             operating-system: windows-latest
 
+    env:
+      JRUBY_OPTS: --debug
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,6 +52,9 @@ jobs:
 
     needs: [build]
     runs-on: ubuntu-latest
+
+    env:
+      JRUBY_OPTS: --debug
 
     steps:
       - name: Checkout

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
-    
+
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 
@@ -31,6 +31,9 @@ jobs:
             operating-system: ubuntu-latest
           - ruby: jruby-head
             operating-system: windows-latest
+
+    env:
+      JRUBY_OPTS: --debug
 
     steps:
       - name: Checkout

--- a/ruby_git.gemspec
+++ b/ruby_git.gemspec
@@ -46,9 +46,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rubocop', '~> 1.66'
-  spec.add_development_dependency 'simplecov', '0.17'
-  spec.add_development_dependency 'simplecov-lcov', '0.8'
-  spec.add_development_dependency 'simplecov-rspec', '0.2'
+  spec.add_development_dependency 'simplecov', '~> 0.22'
+  spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
+  spec.add_development_dependency 'simplecov-rspec', '~> 0.3'
 
   unless RUBY_PLATFORM == 'java'
     spec.add_development_dependency 'redcarpet', '~> 3.6'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,14 +16,17 @@ end
 #
 require 'simplecov'
 require 'simplecov-lcov'
+require 'simplecov-rspec'
 
-if ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
+def ci_build? = ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
+
+if ci_build?
   SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Formatter::LcovFormatter
   ]
 end
 
-SimpleCov.start
+SimpleCov::RSpec.start(list_uncovered_lines: ci_build?)
 
 require 'ruby_git'


### PR DESCRIPTION
simplecov-rspec is a Ruby gem that integrates SimpleCov with RSpec to ensure your tests meet a minimum coverage threshold. It enhances your test suite by automatically failing tests when coverage falls below a specified threshold and, optionally, listing uncovered lines to help you improve coverage.