### PR TITLE
Replace NullLogger with Logger.new(File::NULL)

### DIFF
--- a/lib/ruby_git.rb
+++ b/lib/ruby_git.rb
@@ -6,7 +6,7 @@ require 'ruby_git/git_binary'
 require 'ruby_git/version'
 require 'ruby_git/working_tree'
 
-require 'null_logger'
+require 'logger'
 
 # The RubyGit module provides a Ruby API that is an object-oriented wrapper around
 # the `git` command line. It is intended to make automating both simple and complex Git
@@ -43,12 +43,12 @@ module RubyGit
     attr_reader :git
   end
 
-  @logger = NullLogger.new
+  @logger = Logger.new(File::NULL)
 
   class << self
     # The logger used by the RubyGit gem
     #
-    # The default value is a NullLogger
+    # The default value is a Logger that writes to `/dev/null`.
     #
     # @example Using the logger
     #   RubyGit.logger.debug('Debug message')

--- a/ruby_git.gemspec
+++ b/ruby_git.gemspec
@@ -41,8 +41,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'null-logger', '~> 0.1'
-
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'create_github_release', '~> 1.5'
   spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'

--- a/spec/lib/ruby_git_spec.rb
+++ b/spec/lib/ruby_git_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RubyGit do
     subject { described_class.logger }
 
     context 'when a logger has not be set' do
-      it { is_expected.to be_kind_of(NullLogger) }
+      it { is_expected.to be_kind_of(Logger) }
     end
 
     context 'when a logger has been set' do


### PR DESCRIPTION
Rather than using the null_logger gem, use Ruby's built in class Logger's capability to specify File::NULL to accomplish the same thing: a logger that doesn't actually log anything.

Besides eliminating a dependency, NullLogger was not fully interface compatible with Logger.