### PR TITLE
Rename "WorkingTree" to "Worktree"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ interactions easier. To accomplish this, it ties each action you can do with `gi
 the type of object that action operates on.
 
 There are three main objects in RubyGit:
- * [WorkingTree](lib/ruby_git/working_tree.rb): The directory tree of actual checked
+ * [Worktree](lib/ruby_git/worktree.rb): The directory tree of actual checked
    out files. The working tree normally contains the contents of the HEAD commit’s
    tree, plus any local changes that you have made but not yet committed.
  * [Index](lib/ruby_git/index.rb): The index is used as a staging area between your
@@ -67,24 +67,24 @@ RubyGit.git.path #=> '/usr/local/bin/git'
 RubyGit.git.version #=> [2,28,0]
 ```
 
-To work with an existing WorkingTree:
+To work with an existing Worktree:
 
 ```Ruby
-working_tree = RubyGit.open(working_tree_path)
-working_tree.append_to_file('README.md', 'New line in README.md')
-working_tree.add('README.md')
-working_tree.commit('Add a line to the README.md')
-working_tree.push
+worktree = RubyGit.open(worktree_path)
+worktree.append_to_file('README.md', 'New line in README.md')
+worktree.add('README.md')
+worktree.commit('Add a line to the README.md')
+worktree.push
 ```
 
-To create a new WorkingTree:
+To create a new Worktree:
 
 ```Ruby
-working_tree = RubyGit.init(working_tree_path)
-working_tree.write_to_file('README.md', '# My New Project')
-working_tree.add('README.md')
-working_tree.repository.add_remote(remote_name: 'origin', url: 'https://github.com/jcouball/test', default_branch: 'main')
-working_tree.push(remote_name: 'origin')
+worktree = RubyGit.init(worktree_path)
+worktree.write_to_file('README.md', '# My New Project')
+worktree.add('README.md')
+worktree.repository.add_remote(remote_name: 'origin', url: 'https://github.com/jcouball/test', default_branch: 'main')
+worktree.push(remote_name: 'origin')
 ```
 
 To tell what version of Git is being used:

--- a/lib/ruby_git.rb
+++ b/lib/ruby_git.rb
@@ -4,7 +4,7 @@ require_relative 'ruby_git/command_line'
 require_relative 'ruby_git/encoding_normalizer'
 require_relative 'ruby_git/errors'
 require_relative 'ruby_git/version'
-require_relative 'ruby_git/working_tree'
+require_relative 'ruby_git/worktree'
 
 require 'logger'
 
@@ -14,7 +14,7 @@ require 'logger'
 # the type of object that action operates on.
 #
 # There are three main objects in RubyGit:
-# * {WorkingTree}: The directory tree of actual checked
+# * {Worktree}: The directory tree of actual checked
 #   out files. The working tree normally contains the contents of the HEAD commit's
 #   tree, plus any local changes that you have made but not yet committed.
 # * Index: The index is used as a staging area between your
@@ -77,57 +77,57 @@ module RubyGit
   # @see https://git-scm.com/docs/git-init git-init
   #
   # @example
-  #   working_tree = WorkingTree.init(working_tree_path)
+  #   worktree = Worktree.init(worktree_path)
   #
-  # @param [String] working_tree_path the root path of a working_tree
+  # @param [String] worktree_path the root path of a worktree
   #
-  # @raise [RubyGit::Error] if working_tree_path is not a directory
+  # @raise [RubyGit::Error] if worktree_path is not a directory
   #
-  # @return [RubyGit::WorkingTree] the working_tree whose root is at `path`
+  # @return [RubyGit::Worktree] the worktree whose root is at `path`
   #
-  def self.init(working_tree_path)
-    RubyGit::WorkingTree.init(working_tree_path)
+  def self.init(worktree_path)
+    RubyGit::Worktree.init(worktree_path)
   end
 
-  # Open an existing Git working tree that contains working_tree_path
+  # Open an existing Git working tree that contains worktree_path
   #
   # @see https://git-scm.com/docs/git-open git-open
   #
   # @example
-  #   working_tree = WorkingTree.open(working_tree_path)
+  #   worktree = Worktree.open(worktree_path)
   #
-  # @param [String] working_tree_path the root path of a working_tree
+  # @param [String] worktree_path the root path of a worktree
   #
-  # @raise [RubyGit::Error] if `working_tree_path` does not exist, is not a directory, or is not within
-  #   a Git working_tree.
+  # @raise [RubyGit::Error] if `worktree_path` does not exist, is not a directory, or is not within
+  #   a Git worktree.
   #
-  # @return [RubyGit::WorkingTree] the working_tree that contains `working_tree_path`
+  # @return [RubyGit::Worktree] the worktree that contains `worktree_path`
   #
-  def self.open(working_tree_path)
-    RubyGit::WorkingTree.open(working_tree_path)
+  def self.open(worktree_path)
+    RubyGit::Worktree.open(worktree_path)
   end
 
   # Copy the remote repository and checkout the default branch
   #
   # Clones the repository referred to by `repository_url` into a newly created
   # directory, creates remote-tracking branches for each branch in the cloned repository,
-  # and checks out the default branch in the working_tree whose root directory is `to_path`.
+  # and checks out the default branch in the worktree whose root directory is `to_path`.
   #
   # @see https://git-scm.com/docs/git-clone git-clone
   #
-  # @example Using default for WorkingTree path
+  # @example Using default for Worktree path
   #   FileUtils.pwd
   #    => "/Users/jsmith"
-  #   working_tree = WorkingTree.clone('https://github.com/main-branch/ruby_git.git')
-  #   working_tree.path
+  #   worktree = Worktree.clone('https://github.com/main-branch/ruby_git.git')
+  #   worktree.path
   #    => "/Users/jsmith/ruby_git"
   #
-  # @example Using a specified working_tree_path
+  # @example Using a specified worktree_path
   #   FileUtils.pwd
   #    => "/Users/jsmith"
-  #   working_tree_path = '/tmp/project'
-  #   working_tree = WorkingTree.clone('https://github.com/main-branch/ruby_git.git', to_path: working_tree_path)
-  #   working_tree.path
+  #   worktree_path = '/tmp/project'
+  #   worktree = Worktree.clone('https://github.com/main-branch/ruby_git.git', to_path: worktree_path)
+  #   worktree.path
   #    => "/tmp/project"
   #
   # @param [String] repository_url a reference to a Git repository
@@ -140,10 +140,10 @@ module RubyGit
   # @raise [RubyGit::Error] if (1) `repository_url` is not valid or does not point to a valid repository OR
   #   (2) `to_path` is not an empty directory.
   #
-  # @return [RubyGit::WorkingTree] the working tree checked out from the cloned repository
+  # @return [RubyGit::Worktree] the working tree checked out from the cloned repository
   #
   def self.clone(repository_url, to_path: '')
-    RubyGit::WorkingTree.clone(repository_url, to_path:)
+    RubyGit::Worktree.clone(repository_url, to_path:)
   end
 
   # The version of git referred to by the path

--- a/lib/ruby_git/command_line.rb
+++ b/lib/ruby_git/command_line.rb
@@ -23,12 +23,12 @@ module RubyGit
     #
     # @example A more complex example
     #   command = %w[rev-parse --show-toplevel]
-    #   options = { chdir: working_tree_path, chomp: true, out: StringIO.new, err: StringIO.new }
+    #   options = { chdir: worktree_path, chomp: true, out: StringIO.new, err: StringIO.new }
     #   RubyGit::CommandLine.run(*command, **options).stdout #=> "/path/to/working/tree"
     #
     # @param args [Array<String>] the git command and it arguments
     # @param repository_path [String] the path to the git repository
-    # @param working_tree_path [String] the path to the working tree
+    # @param worktree_path [String] the path to the working tree
     # @param options [Hash<Symbol, Object>] options to pass to the command line runner
     #
     # @return [RubyGit::CommandLine::Result] the result of running the command
@@ -39,11 +39,11 @@ module RubyGit
     # @raise [RubyGit::SignaledError] if the command terminates due to an uncaught signal
     # @raise [RubyGit::ProcessIOError] if an exception is raised while collecting subprocess output
     #
-    def self.run(*args, repository_path: nil, working_tree_path: nil, **options)
+    def self.run(*args, repository_path: nil, worktree_path: nil, **options)
       runner = RubyGit::CommandLine::Runner.new(
         env,
         binary_path,
-        global_options(repository_path:, working_tree_path:),
+        global_options(repository_path:, worktree_path:),
         logger
       )
       runner.call(*args, **options)
@@ -70,10 +70,10 @@ module RubyGit
     # The global options that will be set for all git commands
     # @return [Array<String>]
     # @api private
-    def self.global_options(repository_path:, working_tree_path:) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def self.global_options(repository_path:, worktree_path:) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       [].tap do |global_opts|
         global_opts << "--git-dir=#{repository_path}" unless repository_path.nil?
-        global_opts << "--work-tree=#{working_tree_path}" unless working_tree_path.nil?
+        global_opts << "--work-tree=#{worktree_path}" unless worktree_path.nil?
         global_opts << '-c' << 'core.quotePath=true'
         global_opts << '-c' << 'color.ui=false'
         global_opts << '-c' << 'color.advice=false'

--- a/lib/ruby_git/worktree.rb
+++ b/lib/ruby_git/worktree.rb
@@ -6,18 +6,18 @@ module RubyGit
   # The working tree is a directory tree consisting of the checked out files that
   # you are currently working on.
   #
-  # Create a new WorkingTree using {.init}, {.clone}, or {.open}.
+  # Create a new Worktree using {.init}, {.clone}, or {.open}.
   #
-  class WorkingTree
+  class Worktree
     # The root path of the working tree
     #
     # @example
-    #   working_tree_path = '/Users/James/myproject'
-    #   working_tree = WorkingTree.open(working_tree_path)
-    #   working_tree.path
+    #   worktree_path = '/Users/James/myproject'
+    #   worktree = Worktree.open(worktree_path)
+    #   worktree.path
     #    => '/Users/James/myproject'
     #
-    # @return [Pathname] the root path of the working_tree
+    # @return [Pathname] the root path of the worktree
     #
     attr_reader :path
 
@@ -28,40 +28,40 @@ module RubyGit
     # @see https://git-scm.com/docs/git-init git-init
     #
     # @example
-    #   working_tree = WorkingTree.init(working_tree_path)
+    #   worktree = Worktree.init(worktree_path)
     #
-    # @param [String] working_tree_path the root path of a Git working tree
+    # @param [String] worktree_path the root path of a Git working tree
     #
-    # @raise [RubyGit::Error] if working_tree_path is not a directory
+    # @raise [RubyGit::Error] if worktree_path is not a directory
     #
-    # @return [RubyGit::WorkingTree] the working tree whose root is at `path`
+    # @return [RubyGit::Worktree] the working tree whose root is at `path`
     #
-    def self.init(working_tree_path)
-      raise RubyGit::Error, "Path '#{working_tree_path}' not valid." unless File.directory?(working_tree_path)
+    def self.init(worktree_path)
+      raise RubyGit::Error, "Path '#{worktree_path}' not valid." unless File.directory?(worktree_path)
 
       command = ['init']
-      options = { chdir: working_tree_path, out: StringIO.new, err: StringIO.new }
+      options = { chdir: worktree_path, out: StringIO.new, err: StringIO.new }
       RubyGit::CommandLine.run(*command, **options)
 
-      new(working_tree_path)
+      new(worktree_path)
     end
 
-    # Open an existing Git working tree that contains working_tree_path
+    # Open an existing Git working tree that contains worktree_path
     #
     # @see https://git-scm.com/docs/git-open git-open
     #
     # @example
-    #   working_tree = WorkingTree.open(working_tree_path)
+    #   worktree = Worktree.open(worktree_path)
     #
-    # @param [String] working_tree_path the root path of a Git working tree
+    # @param [String] worktree_path the root path of a Git working tree
     #
-    # @raise [RubyGit::Error] if `working_tree_path` does not exist, is not a directory, or is not within
+    # @raise [RubyGit::Error] if `worktree_path` does not exist, is not a directory, or is not within
     #   a Git working tree.
     #
-    # @return [RubyGit::WorkingTree] the Git working tree that contains `working_tree_path`
+    # @return [RubyGit::Worktree] the Git working tree that contains `worktree_path`
     #
-    def self.open(working_tree_path)
-      new(working_tree_path)
+    def self.open(worktree_path)
+      new(worktree_path)
     end
 
     # Copy the remote repository and checkout the default branch
@@ -72,19 +72,19 @@ module RubyGit
     #
     # @see https://git-scm.com/docs/git-clone git-clone
     #
-    # @example Using default for WorkingTree path
+    # @example Using default for Worktree path
     #   FileUtils.pwd
     #    => "/Users/jsmith"
-    #   working_tree = WorkingTree.clone('https://github.com/main-branch/ruby_git.git')
-    #   working_tree.path
+    #   worktree = Worktree.clone('https://github.com/main-branch/ruby_git.git')
+    #   worktree.path
     #    => "/Users/jsmith/ruby_git"
     #
-    # @example Using a specified working_tree_path
+    # @example Using a specified worktree_path
     #   FileUtils.pwd
     #    => "/Users/jsmith"
-    #   working_tree_path = '/tmp/project'
-    #   working_tree = WorkingTree.clone('https://github.com/main-branch/ruby_git.git', to_path: working_tree_path)
-    #   working_tree.path
+    #   worktree_path = '/tmp/project'
+    #   worktree = Worktree.clone('https://github.com/main-branch/ruby_git.git', to_path: worktree_path)
+    #   worktree.path
     #    => "/tmp/project"
     #
     # @param [String] repository_url a reference to a Git repository
@@ -97,7 +97,7 @@ module RubyGit
     # @raise [RubyGit::FailedError] if (1) `repository_url` is not valid or does not point to a valid repository OR
     #   (2) `to_path` is not an empty directory.
     #
-    # @return [RubyGit::WorkingTree] the Git working tree checked out from the cloned repository
+    # @return [RubyGit::Worktree] the Git working tree checked out from the cloned repository
     #
     def self.clone(repository_url, to_path: '')
       command = ['clone', '--', repository_url, to_path]
@@ -108,13 +108,13 @@ module RubyGit
 
     private
 
-    # Create a WorkingTree object
+    # Create a Worktree object
     # @api private
     #
-    def initialize(working_tree_path)
-      raise RubyGit::Error, "Path '#{working_tree_path}' not valid." unless File.directory?(working_tree_path)
+    def initialize(worktree_path)
+      raise RubyGit::Error, "Path '#{worktree_path}' not valid." unless File.directory?(worktree_path)
 
-      @path = root_path(working_tree_path)
+      @path = root_path(worktree_path)
       RubyGit.logger.debug("Created #{inspect}")
     end
 
@@ -126,14 +126,14 @@ module RubyGit
     #
     # @api private
     #
-    def root_path(working_tree_path)
+    def root_path(worktree_path)
       command = %w[rev-parse --show-toplevel]
-      options = { chdir: working_tree_path, chomp: true, out: StringIO.new, err: StringIO.new }
+      options = { chdir: worktree_path, chomp: true, out: StringIO.new, err: StringIO.new }
       RubyGit::CommandLine.run(*command, **options).stdout
     end
 
     # def run(*command, **options)
-    #   RubyGit::CommandLine.run(*command, working_tree_path: path, **options)
+    #   RubyGit::CommandLine.run(*command, worktree_path: path, **options)
     # end
   end
 end

--- a/spec/lib/ruby_git/working_tree_clone_spec.rb
+++ b/spec/lib/ruby_git/working_tree_clone_spec.rb
@@ -15,9 +15,9 @@ def make_bare_repository(repository_path)
   repository_path
 end
 
-RSpec.describe RubyGit::WorkingTree do
-  describe '.clone(url, to_path: working_tree_path)' do
-    subject { described_class.clone(repository_url, to_path: working_tree_path) }
+RSpec.describe RubyGit::Worktree do
+  describe '.clone(url, to_path: worktree_path)' do
+    subject { described_class.clone(repository_url, to_path: worktree_path) }
     let(:tmpdir) { Dir.mktmpdir }
     let(:repository_url) { make_bare_repository(Dir.mktmpdir) }
     after do
@@ -27,36 +27,36 @@ RSpec.describe RubyGit::WorkingTree do
 
     context 'the url is not valid' do
       before { FileUtils.rm_rf(repository_url) }
-      let(:working_tree_path) { tmpdir }
+      let(:worktree_path) { tmpdir }
       it 'should raise RubyGit::Error' do
         expect { subject }.to raise_error(RubyGit::Error)
       end
     end
 
     context 'the url is valid' do
-      let(:working_tree_path) { tmpdir }
+      let(:worktree_path) { tmpdir }
 
-      context 'and working_tree_path exists' do
+      context 'and worktree_path exists' do
         context 'and is not an empty directory' do
-          before { FileUtils.touch(File.join(working_tree_path, 'README.md')) }
+          before { FileUtils.touch(File.join(worktree_path, 'README.md')) }
           it 'should raise RubyGit::Error' do
             expect { subject }.to raise_error(RubyGit::Error, /not an empty directory/)
           end
         end
 
         context 'and is an empty directory' do
-          it 'should return a  WorkingTree object' do
-            expect(subject).to be_kind_of(RubyGit::WorkingTree)
-            expect(subject).to have_attributes(path: File.realpath(working_tree_path))
+          it 'should return a  Worktree object' do
+            expect(subject).to be_kind_of(RubyGit::Worktree)
+            expect(subject).to have_attributes(path: File.realpath(worktree_path))
           end
         end
       end
-      context 'and working_tree_path does not exist' do
-        before { FileUtils.rmdir(working_tree_path) }
-        it 'should create the working tree path and return a WorkingTree object' do
-          expect(subject).to be_kind_of(RubyGit::WorkingTree)
-          expect(Dir.exist?(working_tree_path)).to eq(true)
-          expect(subject).to have_attributes(path: File.realpath(working_tree_path))
+      context 'and worktree_path does not exist' do
+        before { FileUtils.rmdir(worktree_path) }
+        it 'should create the working tree path and return a Worktree object' do
+          expect(subject).to be_kind_of(RubyGit::Worktree)
+          expect(Dir.exist?(worktree_path)).to eq(true)
+          expect(subject).to have_attributes(path: File.realpath(worktree_path))
         end
       end
     end

--- a/spec/lib/ruby_git/working_tree_init_spec.rb
+++ b/spec/lib/ruby_git/working_tree_init_spec.rb
@@ -2,26 +2,26 @@
 
 require 'tmpdir'
 
-RSpec.describe RubyGit::WorkingTree do
-  describe '.init(working_tree_path)' do
-    subject { described_class.init(working_tree_path) }
+RSpec.describe RubyGit::Worktree do
+  describe '.init(worktree_path)' do
+    subject { described_class.init(worktree_path) }
     let(:tmpdir) { Dir.mktmpdir }
     after { FileUtils.rm_rf(tmpdir) }
 
-    context 'when working_tree_path does not exist' do
-      let(:working_tree_path) { tmpdir }
+    context 'when worktree_path does not exist' do
+      let(:worktree_path) { tmpdir }
       before { FileUtils.rmdir(tmpdir) }
       it 'should raise a RubyGit::Error' do
         expect { subject }.to raise_error(RubyGit::Error)
       end
     end
 
-    context 'when working_tree_path exists' do
-      let(:working_tree_path) { tmpdir }
+    context 'when worktree_path exists' do
+      let(:worktree_path) { tmpdir }
       context 'and is not a directory' do
         before do
-          FileUtils.rmdir(working_tree_path)
-          FileUtils.touch(working_tree_path)
+          FileUtils.rmdir(worktree_path)
+          FileUtils.touch(worktree_path)
         end
         it 'should raise RubyGit::Error' do
           expect { subject }.to raise_error(RubyGit::Error)
@@ -31,18 +31,18 @@ RSpec.describe RubyGit::WorkingTree do
       context 'and is a directory' do
         context 'and is in a working tree' do
           before do
-            raise RuntimeError unless system('git init', chdir: working_tree_path, %i[out err] => IO::NULL)
+            raise RuntimeError unless system('git init', chdir: worktree_path, %i[out err] => IO::NULL)
           end
-          it 'should return a WorkingTree object to the existing working tree' do
-            expect(subject).to be_kind_of(RubyGit::WorkingTree)
-            expect(subject).to have_attributes(path: File.realpath(working_tree_path))
+          it 'should return a Worktree object to the existing working tree' do
+            expect(subject).to be_kind_of(RubyGit::Worktree)
+            expect(subject).to have_attributes(path: File.realpath(worktree_path))
           end
         end
 
         context 'and is not in the working tree' do
-          it 'should initialize the working tree and return a WorkingTree object' do
-            expect(subject).to be_kind_of(RubyGit::WorkingTree)
-            expect(subject).to have_attributes(path: File.realpath(working_tree_path))
+          it 'should initialize the working tree and return a Worktree object' do
+            expect(subject).to be_kind_of(RubyGit::Worktree)
+            expect(subject).to have_attributes(path: File.realpath(worktree_path))
           end
         end
       end

--- a/spec/lib/ruby_git/working_tree_initialize_spec.rb
+++ b/spec/lib/ruby_git/working_tree_initialize_spec.rb
@@ -4,24 +4,24 @@ require 'logger'
 require 'stringio'
 require 'tmpdir'
 
-RSpec.describe RubyGit::WorkingTree do
+RSpec.describe RubyGit::Worktree do
   describe '.initialize' do
-    subject { described_class.open(working_tree_path) }
+    subject { described_class.open(worktree_path) }
     let(:tmpdir) { Dir.mktmpdir }
     after { FileUtils.rm_rf(tmpdir) }
 
     context 'with a valid working tree path' do
-      let(:working_tree_path) { tmpdir }
+      let(:worktree_path) { tmpdir }
       before do
-        raise RuntimeError unless system('git init', chdir: working_tree_path, %i[out err] => IO::NULL)
+        raise RuntimeError unless system('git init', chdir: worktree_path, %i[out err] => IO::NULL)
       end
-      it 'should log that a WorkingTree object was created at debug level' do
+      it 'should log that a Worktree object was created at debug level' do
         log_device = StringIO.new
         saved_logger = RubyGit.logger
         RubyGit.logger = Logger.new(log_device, level: Logger::DEBUG)
-        RubyGit::WorkingTree.new(working_tree_path)
+        RubyGit::Worktree.new(worktree_path)
         RubyGit.logger = saved_logger
-        expect(log_device.string).to include(' : Created #<RubyGit::WorkingTree:')
+        expect(log_device.string).to include(' : Created #<RubyGit::Worktree:')
       end
     end
   end

--- a/spec/lib/ruby_git/working_tree_open_spec.rb
+++ b/spec/lib/ruby_git/working_tree_open_spec.rb
@@ -2,59 +2,59 @@
 
 require 'tmpdir'
 
-RSpec.describe RubyGit::WorkingTree do
+RSpec.describe RubyGit::Worktree do
   describe '.open' do
-    subject { described_class.open(working_tree_path) }
+    subject { described_class.open(worktree_path) }
     let(:tmpdir) { Dir.mktmpdir }
     after { FileUtils.rm_rf(tmpdir) }
 
-    context 'when working_tree_path does not exist' do
-      let(:working_tree_path) { tmpdir }
-      before { FileUtils.rmdir(working_tree_path) }
+    context 'when worktree_path does not exist' do
+      let(:worktree_path) { tmpdir }
+      before { FileUtils.rmdir(worktree_path) }
       it 'should  raise RubyGit::Error' do
         expect { subject }.to raise_error(RubyGit::Error)
       end
     end
 
-    context 'when working_tree_path is not a directory' do
-      let(:working_tree_path) { tmpdir }
+    context 'when worktree_path is not a directory' do
+      let(:worktree_path) { tmpdir }
       before do
-        FileUtils.rmdir(working_tree_path)
-        FileUtils.touch(working_tree_path)
+        FileUtils.rmdir(worktree_path)
+        FileUtils.touch(worktree_path)
       end
       it 'should raise RubyGit::Error' do
         expect { subject }.to raise_error(RubyGit::Error)
       end
     end
 
-    context 'when working_tree_path exists but is not a git working tree' do
-      let(:working_tree_path) { tmpdir }
+    context 'when worktree_path exists but is not a git working tree' do
+      let(:worktree_path) { tmpdir }
       it 'should raise RubyGit::Error' do
         expect { subject }.to raise_error(RubyGit::Error, /not a git repository/)
       end
     end
 
-    context 'when working_tree_path is a working tree path at the root of the working tree' do
-      let(:working_tree_path) { tmpdir }
+    context 'when worktree_path is a working tree path at the root of the working tree' do
+      let(:worktree_path) { tmpdir }
       before do
-        raise RuntimeError unless system('git init', chdir: working_tree_path, %i[out err] => IO::NULL)
+        raise RuntimeError unless system('git init', chdir: worktree_path, %i[out err] => IO::NULL)
       end
-      it 'should return a WorkingTree object whose path is the root of the working tree' do
-        expect(subject).to be_kind_of(RubyGit::WorkingTree)
-        expect(subject).to have_attributes(path: File.realpath(working_tree_path))
+      it 'should return a Worktree object whose path is the root of the working tree' do
+        expect(subject).to be_kind_of(RubyGit::Worktree)
+        expect(subject).to have_attributes(path: File.realpath(worktree_path))
       end
     end
 
-    context 'when working_tree_path is a working tree path not at the root of the working tree' do
-      let(:root_working_tree_path) { tmpdir }
-      let(:working_tree_path) { File.join(root_working_tree_path, 'subdir') }
+    context 'when worktree_path is a working tree path not at the root of the working tree' do
+      let(:root_worktree_path) { tmpdir }
+      let(:worktree_path) { File.join(root_worktree_path, 'subdir') }
       before do
-        raise RuntimeError unless system('git init', chdir: root_working_tree_path, %i[out err] => IO::NULL)
+        raise RuntimeError unless system('git init', chdir: root_worktree_path, %i[out err] => IO::NULL)
 
-        FileUtils.mkdir(working_tree_path)
+        FileUtils.mkdir(worktree_path)
       end
-      it 'should return a WorkingTree object whose path is the root of the working_tree' do
-        expect(subject).to have_attributes(path: File.realpath(root_working_tree_path))
+      it 'should return a Worktree object whose path is the root of the worktree' do
+        expect(subject).to have_attributes(path: File.realpath(root_worktree_path))
       end
     end
   end

--- a/spec/lib/ruby_git_spec.rb
+++ b/spec/lib/ruby_git_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe RubyGit do
   end
 
   describe '.init' do
-    let(:working_tree_path) { '/Users/jsmith/my_project' }
-    subject { RubyGit.init(working_tree_path) }
-    it 'should call RubyGit::WorkingTree.init with the same arguments' do
-      working_tree_class = class_double('RubyGit::WorkingTree')
-      stub_const('RubyGit::WorkingTree', working_tree_class)
-      expect(working_tree_class).to receive(:init).with(working_tree_path)
+    let(:worktree_path) { '/Users/jsmith/my_project' }
+    subject { RubyGit.init(worktree_path) }
+    it 'should call RubyGit::Worktree.init with the same arguments' do
+      worktree_class = class_double('RubyGit::Worktree')
+      stub_const('RubyGit::Worktree', worktree_class)
+      expect(worktree_class).to receive(:init).with(worktree_path)
       subject
     end
   end
@@ -53,21 +53,21 @@ RSpec.describe RubyGit do
   describe '.clone' do
     let(:repository_url) { 'https://github.com/main-branch/ruby_git.git' }
     subject { RubyGit.clone(repository_url) }
-    it 'should call RubyGit::WorkingTree.clone with the same arguments' do
-      working_tree_class = class_double('RubyGit::WorkingTree')
-      stub_const('RubyGit::WorkingTree', working_tree_class)
-      expect(working_tree_class).to receive(:clone).with(repository_url, to_path: '')
+    it 'should call RubyGit::Worktree.clone with the same arguments' do
+      worktree_class = class_double('RubyGit::Worktree')
+      stub_const('RubyGit::Worktree', worktree_class)
+      expect(worktree_class).to receive(:clone).with(repository_url, to_path: '')
       subject
     end
   end
 
   describe '.open' do
-    let(:working_tree_path) { '/Users/jsmith/my_project' }
-    subject { RubyGit.open(working_tree_path) }
-    it 'should call RubyGit::WorkingTree.open with the same arguments' do
-      working_tree_class = class_double('RubyGit::WorkingTree')
-      stub_const('RubyGit::WorkingTree', working_tree_class)
-      expect(working_tree_class).to receive(:open).with(working_tree_path)
+    let(:worktree_path) { '/Users/jsmith/my_project' }
+    subject { RubyGit.open(worktree_path) }
+    it 'should call RubyGit::Worktree.open with the same arguments' do
+      worktree_class = class_double('RubyGit::Worktree')
+      stub_const('RubyGit::Worktree', worktree_class)
+      expect(worktree_class).to receive(:open).with(worktree_path)
       subject
     end
   end


### PR DESCRIPTION
# Description

Git makes the distinction between these two terms which is lost on many beginners. Here is the official definition from the git glossary:

**[Working tree](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefworkingtreeaworkingtree)**

The tree of actual checked out files. The working tree normally contains the contents of the HEAD commit’s tree, plus any local changes that you have made but not yet committed.

**[Worktree](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefworktreeaworktree)**

A repository can have zero (i.e. bare repository) or one or more worktrees attached to it. One "worktree" consists of a "working tree" and repository metadata, most of which are shared among other worktrees of a single repository, and some of which are maintained separately per worktree (e.g. the index, HEAD and pseudorefs like MERGE_HEAD, per-worktree refs and per-worktree configuration file).

## How "Working Tree" and "Worktree" will be used in this project

In particular, the `WorkingTree` class really represents a worktree so that class will be renamed.

This library will use the term **worktree** in most (if not all) cases. This is so that people don't have to think about which term is the most appropriate.