### PR TITLE
Make Worktree#clone handle optional clone_to path and use realpath for paths

### DIFF
--- a/lib/ruby_git/repository.rb
+++ b/lib/ruby_git/repository.rb
@@ -27,7 +27,7 @@ module RubyGit
     # @param [String] repository_path the path to the repository
     #
     def initialize(repository_path)
-      @path = File.expand_path(repository_path)
+      @path = File.realpath(repository_path)
     end
   end
 end

--- a/spec/lib/ruby_git/repository_spec.rb
+++ b/spec/lib/ruby_git/repository_spec.rb
@@ -2,12 +2,18 @@
 
 RSpec.describe RubyGit::Repository do
   let(:repository) { RubyGit::Repository.new(repository_path) }
+  let(:repository_path) { File.realpath(@repository_path) }
 
   describe '#initialize' do
-    subject { repository }
-
     context 'when given a repository path' do
-      let(:repository_path) { File.expand_path('/path/to/repository') }
+      around do |example|
+        in_temp_dir do |repository_path|
+          @repository_path = repository_path
+          example.run
+        end
+      end
+
+      subject { repository }
 
       it 'should set the path to the given repository path' do
         expect(subject).to have_attributes(path: repository_path)

--- a/spec/lib/ruby_git/worktree_clone_spec.rb
+++ b/spec/lib/ruby_git/worktree_clone_spec.rb
@@ -16,6 +16,29 @@ def make_bare_repository(repository_path)
 end
 
 RSpec.describe RubyGit::Worktree do
+  describe '.clone(url)' do
+    subject { described_class.clone(repository_url) }
+    let(:repository_url) { 'repository.git' }
+
+    around do |example|
+      in_temp_dir do |path|
+        @path = path
+
+        in_dir repository_url do
+          run %w[git init --initial-branch=main]
+        end
+        example.run
+      end
+    end
+
+    let(:expected_worktree_path) { File.realpath(File.join(@path, 'repository')) }
+
+    it 'should return a Worktree object with the correct path' do
+      expect(subject).to be_kind_of(RubyGit::Worktree)
+      expect(subject).to have_attributes(path: expected_worktree_path)
+    end
+  end
+
   describe '.clone(url, to_path: worktree_path)' do
     subject { described_class.clone(repository_url, to_path: worktree_path) }
     let(:tmpdir) { Dir.mktmpdir }

--- a/spec/lib/ruby_git/worktree_spec.rb
+++ b/spec/lib/ruby_git/worktree_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe RubyGit::Worktree do
     subject { worktree.repository }
 
     it { is_expected.to be_a(RubyGit::Repository) }
-    it { is_expected.to have_attributes(path: File.expand_path('./.git')) }
+    it { is_expected.to have_attributes(path: File.realpath('./.git')) }
   end
 end


### PR DESCRIPTION
Enhance the Worktree#clone method to function correctly when the clone_to path is not provided. Update path handling to use File#realpath for consistent and determinate path resolution.