### PR TITLE
Add status report entry filters

### DIFF
--- a/lib/ruby_git/status/entry.rb
+++ b/lib/ruby_git/status/entry.rb
@@ -85,11 +85,78 @@ module RubyGit
       # Get the worktree status
       #
       # @example
-      #   entry.worktree_status #=> :unchanged
+      #   entry.worktree_status #=> :unmodified
       #
       # @return [Symbol, nil] worktree status symbol or nil if not applicable
       #
       def worktree_status = nil
+
+      # Is the entry an ignored file?
+      #
+      # * Ignored entries are not considered untracked
+      #
+      # @example
+      #   entry.ignored? #=> false
+      #
+      # @return [Boolean]
+      #
+      def ignored? = false
+
+      # Is the entry an untracked file?
+      #
+      # * Ignored entries are not considered untracked
+      #
+      # @example
+      #   entry.ignored? #=> false
+      #
+      # @return [Boolean]
+      #
+      def untracked? = false
+
+      # Does the entry have unstaged changes in the worktree?
+      #
+      # * An entry can have both staged and unstaged changes
+      # * All untracked entries are considered unstaged
+      #
+      # @example
+      #   entry.ignored? #=> false
+      #
+      # @return [Boolean]
+      #
+      def unstaged? = false
+
+      # Does the entry have staged changes in the index?
+      #
+      # * An entry can have both staged and unstaged changes
+      #
+      # @example
+      #   entry.ignored? #=> false
+      #
+      # @return [Boolean]
+      #
+      def staged? = false
+
+      # Does the entry have staged changes in the index with no unstaged changes?
+      #
+      # * An entry can have both staged and unstaged changes
+      #
+      # @example
+      #   entry.fully_staged? #=> false
+      #
+      # @return [Boolean]
+      #
+      def fully_staged? = staged? && !unstaged?
+
+      # Does the entry represent a merge conflict?
+      #
+      # * Merge conflicts are not considered untracked, staged or unstaged
+      #
+      # @example
+      #   entry.conflict? #=> false
+      #
+      # @return [Boolean]
+      #
+      def unmerged? = false
     end
   end
 end

--- a/lib/ruby_git/status/ignored_entry.rb
+++ b/lib/ruby_git/status/ignored_entry.rb
@@ -31,6 +31,14 @@ module RubyGit
       def initialize(path:)
         super(path)
       end
+
+      # Is the entry an ignored file?
+      # @example
+      #   entry.ignored? #=> false
+      # @return [Boolean]
+      def ignored?
+        true
+      end
     end
   end
 end

--- a/lib/ruby_git/status/ordinary_entry.rb
+++ b/lib/ruby_git/status/ordinary_entry.rb
@@ -179,6 +179,29 @@ module RubyGit
         @head_sha = head_sha
         @index_sha = index_sha
       end
+
+      # Does the entry have unstaged changes in the worktree?
+      #
+      # * An entry can have both staged and unstaged changes
+      # * All untracked entries are considered unstaged
+      #
+      # @example
+      #   entry.ignored? #=> false
+      # @return [Boolean]
+      def unstaged?
+        worktree_status != :unmodified
+      end
+
+      # Does the entry have staged changes in the index?
+      #
+      # * An entry can have both staged and unstaged changes
+      #
+      # @example
+      #   entry.ignored? #=> false
+      # @return [Boolean]
+      def staged?
+        index_status != :unmodified
+      end
     end
   end
 end

--- a/lib/ruby_git/status/renamed_entry.rb
+++ b/lib/ruby_git/status/renamed_entry.rb
@@ -229,6 +229,29 @@ module RubyGit
         @similarity = similarity_score
         @original_path = original_path
       end
+
+      # Does the entry have unstaged changes in the worktree?
+      #
+      # * An entry can have both staged and unstaged changes
+      # * All untracked entries are considered unstaged
+      #
+      # @example
+      #   entry.ignored? #=> false
+      # @return [Boolean]
+      def unstaged?
+        worktree_status != :unmodified
+      end
+
+      # Does the entry have staged changes in the index?
+      #
+      # * An entry can have both staged and unstaged changes
+      #
+      # @example
+      #   entry.ignored? #=> false
+      # @return [Boolean]
+      def staged?
+        index_status != :unmodified
+      end
     end
   end
 end

--- a/lib/ruby_git/status/report.rb
+++ b/lib/ruby_git/status/report.rb
@@ -60,6 +60,84 @@ module RubyGit
         @stash = stash
         @entries = entries
       end
+
+      # The entries that are ignored
+      #
+      # @example
+      #   report.ignored #=> [#<RubyGit::Status::IgnoredEntry ...>, ...]
+      #
+      # @return [Array<IgnoredEntry>]
+      #
+      def ignored
+        entries.select(&:ignored?)
+      end
+
+      # The entries that are untracked
+      #
+      # @example
+      #   report.untracked #=> [#<RubyGit::Status::UntrackedEntry ...>, ...]
+      #
+      # @return [Array<UntrackedEntry>]
+      #
+      def untracked
+        entries.select(&:untracked?)
+      end
+
+      # The entries that have unstaged changes
+      #
+      # @example
+      #   report.unstaged #=> [#<RubyGit::Status::OrdinaryEntry ...>, ...]
+      #
+      # @return [Array<UntrackedEntry, OrdinaryEntry, RenamedEntry>]
+      #
+      def unstaged
+        entries.select(&:unstaged?)
+      end
+
+      # The entries that have staged changes
+      #
+      # @example
+      #   report.staged #=> [#<RubyGit::Status::OrdinaryEntry ...>, ...]
+      #
+      # @return [Array<UntrackedEntry, OrdinaryEntry, RenamedEntry>]
+      #
+      def staged
+        entries.select(&:staged?)
+      end
+
+      # The entries that have staged changes and no unstaged changes
+      #
+      # @example
+      #   report.fully_staged #=> [#<RubyGit::Status::OrdinaryEntry ...>, ...]
+      #
+      # @return [Array<UntrackedEntry, OrdinaryEntry, RenamedEntry>]
+      #
+      def fully_staged
+        entries.select(&:fully_staged?)
+      end
+
+      # The entries that represent merge conflicts
+      #
+      # @example
+      #   report.unmerged #=> [#<RubyGit::Status::UnmergedEntry ...>, ...]
+      #   report.merge_conflicts? #=> true
+      #
+      # @return [Array<UnmergedEntry>]
+      #
+      def unmerged
+        entries.select(&:unmerged?)
+      end
+
+      # Are there any unmerged entries?
+      #
+      # @example
+      #   report.merge_conflicts? #=> true
+      #
+      # @return [Boolean]
+      #
+      def merge_conflict?
+        unmerged.any?
+      end
     end
   end
 end

--- a/lib/ruby_git/status/unmerged_entry.rb
+++ b/lib/ruby_git/status/unmerged_entry.rb
@@ -232,6 +232,17 @@ module RubyGit
         @their_sha = their_sha
         @path = path
       end
+
+      # Does the entry represent a merge conflict?
+      #
+      # * Merge conflicts are not considered untracked, staged or unstaged
+      #
+      # @example
+      #   entry.conflict? #=> false
+      #
+      # @return [Boolean]
+      #
+      def unmerged? = true
     end
   end
 end

--- a/lib/ruby_git/status/untracked_entry.rb
+++ b/lib/ruby_git/status/untracked_entry.rb
@@ -31,6 +31,22 @@ module RubyGit
       def initialize(path:)
         super(path)
       end
+
+      # Is the entry an untracked file?
+      # @example
+      #   entry.ignored? #=> false
+      # @return [Boolean]
+      def untracked? = true
+
+      # Does the entry have unstaged changes in the worktree?
+      #
+      # * An entry can have both staged and unstaged changes
+      # * All untracked entries are considered unstaged
+      #
+      # @example
+      #   entry.ignored? #=> false
+      # @return [Boolean]
+      def unstaged? = true
     end
   end
 end

--- a/spec/lib/ruby_git/status_spec.rb
+++ b/spec/lib/ruby_git/status_spec.rb
@@ -294,5 +294,89 @@ RSpec.describe RubyGit::Status do
         expect { subject }.not_to raise_error
       end
     end
+
+    describe 'filters' do
+      let(:data) do
+        '1 M. N... 000000 100644 100644 0000000000000000000000000000000000000000 ' \
+          "49351eb5b7e355128f8f569d5b3355c3e2a51d4b file1.txt\u0000" \
+          '1 MM N... 000000 100644 100644 0000000000000000000000000000000000000000 ' \
+          "49351eb5b7e355128f8f569d5b3355c3e2a51d4b file2.txt\u0000" \
+          '1 .M N... 000000 100644 100644 0000000000000000000000000000000000000000 ' \
+          "49351eb5b7e355128f8f569d5b3355c3e2a51d4b file3.txt\u0000" \
+          '2 RD N... 100644 100755 000000 1111111111111111111111111111111111111111 ' \
+          "2222222222222222222222222222222222222222 R100 file4.txt\u0000" \
+          "file4_old.txt\u0000" \
+          '2 R. N... 100644 100755 000000 1111111111111111111111111111111111111111 ' \
+          "2222222222222222222222222222222222222222 R100 file5.txt\u0000" \
+          "file5_old.txt\u0000" \
+          'u UU N... 100644 100755 000000 100755 ' \
+          '1111111111111111111111111111111111111111 2222222222222222222222222222222222222222 ' \
+          '3333333333333333333333333333333333333333 file6.txt' \
+          "\u0000" \
+          "? file7.txt\u0000" \
+          "? file8.txt\u0000" \
+          "! file9.txt\u0000"
+      end
+
+      describe '#ignored' do
+        subject { report.ignored }
+        it 'should return the ignored entries' do
+          expect(subject.map(&:path)).to eq(%w[file9.txt])
+        end
+      end
+
+      describe '#untracked' do
+        subject { report.untracked }
+        it 'should return the untracked entries' do
+          expect(subject.map(&:path)).to eq(%w[file7.txt file8.txt])
+        end
+      end
+
+      describe '#unstaged' do
+        subject { report.unstaged }
+        it 'should return the unstaged entries' do
+          expect(subject.map(&:path)).to eq(%w[file2.txt file3.txt file4.txt file7.txt file8.txt])
+        end
+      end
+
+      describe '#staged' do
+        subject { report.staged }
+        it 'should return the staged entries' do
+          expect(subject.map(&:path)).to eq(%w[file1.txt file2.txt file4.txt file5.txt])
+        end
+      end
+
+      describe '#fully_staged' do
+        subject { report.fully_staged }
+        it 'should return the fully staged entries' do
+          expect(subject.map(&:path)).to eq(%w[file1.txt file5.txt])
+        end
+      end
+
+      describe '#unmerged' do
+        subject { report.unmerged }
+        it 'should return the unmerged entries' do
+          expect(subject.map(&:path)).to eq(%w[file6.txt])
+        end
+      end
+    end
+
+    describe '#merge_conflict?' do
+      subject { report.merge_conflict? }
+      context 'when there is a merge conflict' do
+        let(:data) do
+          'u UU N... 100644 100755 000000 100755 ' \
+            '1111111111111111111111111111111111111111 2222222222222222222222222222222222222222 ' \
+            '3333333333333333333333333333333333333333 file6.txt'
+        end
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when there is not a merge conflict' do
+        let(:data) { '' }
+        it { is_expected.to eq(false) }
+      end
+    end
   end
 end


### PR DESCRIPTION
Add filters to `RubyGit::Status::Report` be able to get different categories of entries:
* `#ignored`: entries that are ignored by git
* `#untracked`: entries that are not tracked in the index
* `#unstaged`: entries changed in the working directory
* `#staged`: entries changed in the index
* `#fully_staged`: entries changed in the index but not the working directory
* `#unmerged`: entries that have a merge conflict that must be resolved

Add `#merge_conflict?` to determine if thare are unmerged entries.