### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Change Log
 
+## v0.3.0 (2025-03-28)
+
+[Full Changelog](https://github.com/main-branch/ruby_git/compare/v0.2.0..v0.3.0)
+
+Changes since v0.2.0:
+
+* 89cf543 chore: add the implementation plan
+* 3e952c0 feat: add status report entry filters
+* 301c7b7 feat: support git add via Worktree#add
+* 72020b9 feat: add support to passing path specs to Worktree#status
+* 324a472 test: add tests to verify that Worktree#status builds the right git command
+* c07b3be feat: make Worktree#clone work if clone_to path is not given
+* d7a3232 feat: add Worktree#status
+* 7bae4b6 feat: implement RubyGit::Worktree#status
+* f75e0ec chore: rename working tree to worktree
+* 918487c chore: run git commands using RubyGit::CommandLine.run
+* 8a5b204 fix: fix tests failing on Windows for platform-specific reasons
+* 19eb327 fix: make it so command-line-test script runs in Windows
+* 7fb57c5 refactor: change the way that the git command is run
+* 6efdf53 chore: update process_executer dependency to 3.0
+* 834b33d test: add command line tool to run to test running the command line
+* e74affb chore: make it easier to identify the platform and ruby engine in scripts
+* ceaf40d build: remove semver pr label check
+* 6e56dd0 build: enforce conventional commit message formatting
+* 209c408 Replace NullLogger with Logger.new(File::NULL)
+* 9b23e0f Use shared Rubocop config
+* acb286e Update copyright notice in this project
+* 549d8fb Update links in gemspec
+* 6de1b82 Use standard badges at the top of the README
+* 1fa584e Update yardopts with new standard options
+* 872cd1b Rename "markdown.yml" to ".markdown.yml"
+* ec8299a Standardize YARD and Markdown Lint configurations
+* 1862fc9 Update CODEOWNERS file
+* 6de3eea Set JRuby --debug option when running tests in GitHub Actions workflows
+* 50fda86 Integrate simplecov-rspec into the project
+* 4b7410b Use create-github-release for creating releases
+* 5fd999b Reset CodeClimate code coverage reporter id
+* 7944490 Update continuous integration and experimental ruby builds
+* 943c687 Enforce the use of semver tags on PRs
+* 4e7126a Update minimum required Ruby to 3.1
+* 359c358 Don't enforce coverage % in an RSpec dry run (#30)
+* efa2c90 Use GitHub Actions for CI Builds (#29)
+* d1ca85b Upgrade to Rubocop 1.0 (#25)
+* 6c8fd7a Rename Worktree class to WorkingTree (#24)
+* 88f7471 Remove MAINTAINERS.md from yard documentation (#23)
+* a55042d Add logging to the RubyGit gem (#22)
+* 9a95a32 Redesign RubyGit::FileHelpers.which (#20)
+* 9bb7dc0 Allow members of @main-branch/ruby_git-codeowners to do code review approvals. (#19)
+* 401e1fd Release v0.2.0 (#18)
+
 ## [v0.2.0](https://github.com/main-branch/ruby_git/releases/tag/v0.2.0) (2020-10-12)
 
 [Full Changelog](https://github.com/main-branch/ruby_git/compare/v0.1.3...v0.2.0)

--- a/lib/ruby_git/version.rb
+++ b/lib/ruby_git/version.rb
@@ -3,5 +3,5 @@
 module RubyGit
   # The ruby_git gem version
   #
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
# Release PR

## v0.3.0 (2025-03-28)

[Full Changelog](https://github.com/main-branch/ruby_git/compare/v0.2.0..v0.3.0)

Changes since v0.2.0:

* 89cf543 chore: add the implementation plan
* 3e952c0 feat: add status report entry filters
* 301c7b7 feat: support git add via Worktree#add
* 72020b9 feat: add support to passing path specs to Worktree#status
* 324a472 test: add tests to verify that Worktree#status builds the right git command
* c07b3be feat: make Worktree#clone work if clone_to path is not given
* d7a3232 feat: add Worktree#status
* 7bae4b6 feat: implement RubyGit::Worktree#status
* f75e0ec chore: rename working tree to worktree
* 918487c chore: run git commands using RubyGit::CommandLine.run
* 8a5b204 fix: fix tests failing on Windows for platform-specific reasons
* 19eb327 fix: make it so command-line-test script runs in Windows
* 7fb57c5 refactor: change the way that the git command is run
* 6efdf53 chore: update process_executer dependency to 3.0
* 834b33d test: add command line tool to run to test running the command line
* e74affb chore: make it easier to identify the platform and ruby engine in scripts
* ceaf40d build: remove semver pr label check
* 6e56dd0 build: enforce conventional commit message formatting
* 209c408 Replace NullLogger with Logger.new(File::NULL)
* 9b23e0f Use shared Rubocop config
* acb286e Update copyright notice in this project
* 549d8fb Update links in gemspec
* 6de1b82 Use standard badges at the top of the README
* 1fa584e Update yardopts with new standard options
* 872cd1b Rename "markdown.yml" to ".markdown.yml"
* ec8299a Standardize YARD and Markdown Lint configurations
* 1862fc9 Update CODEOWNERS file
* 6de3eea Set JRuby --debug option when running tests in GitHub Actions workflows
* 50fda86 Integrate simplecov-rspec into the project
* 4b7410b Use create-github-release for creating releases
* 5fd999b Reset CodeClimate code coverage reporter id
* 7944490 Update continuous integration and experimental ruby builds
* 943c687 Enforce the use of semver tags on PRs
* 4e7126a Update minimum required Ruby to 3.1
* 359c358 Don't enforce coverage % in an RSpec dry run (#30)
* efa2c90 Use GitHub Actions for CI Builds (#29)
* d1ca85b Upgrade to Rubocop 1.0 (#25)
* 6c8fd7a Rename Worktree class to WorkingTree (#24)
* 88f7471 Remove MAINTAINERS.md from yard documentation (#23)
* a55042d Add logging to the RubyGit gem (#22)
* 9a95a32 Redesign RubyGit::FileHelpers.which (#20)
* 9bb7dc0 Allow members of @main-branch/ruby_git-codeowners to do code review approvals. (#19)
* 401e1fd Release v0.2.0 (#18)
