### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v0.3.1 (2025-03-28)
+
+[Full Changelog](https://github.com/main-branch/ruby_git/compare/v0.3.0..v0.3.1)
+
+Changes since v0.3.0:
+
+* fbadc20 docs: update the gem description
+
 ## v0.3.0 (2025-03-28)
 
 [Full Changelog](https://github.com/main-branch/ruby_git/compare/v0.2.0..v0.3.0)

--- a/lib/ruby_git/version.rb
+++ b/lib/ruby_git/version.rb
@@ -3,5 +3,5 @@
 module RubyGit
   # The ruby_git gem version
   #
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
# Release PR

## v0.3.1 (2025-03-28)

[Full Changelog](https://github.com/main-branch/ruby_git/compare/v0.3.0..v0.3.1)

Changes since v0.3.0:

* fbadc20 docs: update the gem description
