### PR TITLE
Make path normalization for Worktree and Repository optional

### DIFF
--- a/lib/ruby_git/repository.rb
+++ b/lib/ruby_git/repository.rb
@@ -25,9 +25,50 @@ module RubyGit
     #   RubyGit::Repository.new('/path/to/repository') #=> #<RubyGit::Repository ...>
     #
     # @param [String] repository_path the path to the repository
+    # @param normalize_path [Boolean] if true, path is converted to an absolute path to the root of the working tree
     #
-    def initialize(repository_path)
-      @path = File.realpath(repository_path)
+    #   The purpose of this flag is to allow tests to not have to mock the
+    #   normalization of the path. This allows testing that the right git command
+    #   is contructed based on the options passed any particular method.
+    #
+    # @raise [ArgumentError] if the path is not a directory
+    #
+    def initialize(repository_path, normalize_path: true)
+      @normalize_path = normalize_path
+
+      @path =
+        if normalize_path?
+          normalize_path(repository_path)
+        else
+          repository_path
+        end
+    end
+
+    private
+
+    # true if the path should be expanded and converted to a absolute, real path
+    # @return [Boolean]
+    # @api private
+    def normalize_path? = @normalize_path
+
+    # Expand and convert the given path to an absolute, real path
+    #
+    # @example Expand the path
+    #   normalize_path('~/repository.git') #=> '/Users/james/repository.git'
+    #
+    # @example Convert to an absolute path
+    #   File.chdir('/User/james/repository/.git')
+    #   normalize_path('.') #=> '/User/james/repository/.git'
+    #
+    # @param path [String] the path to normalize
+    #
+    # @return [String]
+    #
+    # @api private
+    def normalize_path(path)
+      raise ArgumentError, "Directory '#{path}' does not exist." unless File.directory?(path)
+
+      File.realpath(File.expand_path(path))
     end
   end
 end

--- a/spec/lib/ruby_git/repository_spec.rb
+++ b/spec/lib/ruby_git/repository_spec.rb
@@ -1,21 +1,29 @@
 # frozen_string_literal: true
 
 RSpec.describe RubyGit::Repository do
-  let(:repository) { RubyGit::Repository.new(repository_path) }
-  let(:repository_path) { File.realpath(@repository_path) }
+  let(:repository) { RubyGit::Repository.new(repository_path, normalize_path:) }
+  let(:repository_path) { '.' }
 
   describe '#initialize' do
-    context 'when given a repository path' do
-      around do |example|
-        in_temp_dir do |repository_path|
-          @repository_path = repository_path
-          example.run
-        end
+    subject { repository }
+
+    around do |example|
+      in_temp_dir do |_repository_path|
+        example.run
       end
+    end
 
-      subject { repository }
+    context 'when normalize_path is true' do
+      let(:normalize_path) { true }
+      it 'path should be the absolute path to the repository' do
+        expected_path = File.realpath(File.expand_path(repository_path))
+        expect(subject).to have_attributes(path: expected_path)
+      end
+    end
 
-      it 'should set the path to the given repository path' do
+    context 'when normalize_path is false' do
+      let(:normalize_path) { false }
+      it 'path should be as given' do
         expect(subject).to have_attributes(path: repository_path)
       end
     end

--- a/spec/lib/ruby_git/worktree_add_spec.rb
+++ b/spec/lib/ruby_git/worktree_add_spec.rb
@@ -2,24 +2,25 @@
 
 RSpec.describe RubyGit::Worktree do
   let(:worktree) { described_class.open(worktree_path) }
-  let(:worktree_path) { @worktree_path }
 
   describe '#add' do
     subject { worktree.add(*pathspecs, **options) }
 
-    around do |example|
-      in_temp_dir do |path|
-        @worktree_path = path
-        run %w[git init --initial-branch=main]
-        File.write('file1.txt', 'file1 contents')
-        File.write('file2.txt', 'file2 contents')
-        Dir.mkdir 'subdir'
-        File.write('subdir/file3.txt', 'file3 contents')
-        example.run
-      end
-    end
-
     describe 'adding changes to the index' do
+      let(:worktree_path) { @worktree_path }
+
+      around do |example|
+        in_temp_dir do |path|
+          @worktree_path = path
+          run %w[git init --initial-branch=main]
+          File.write('file1.txt', 'file1 contents')
+          File.write('file2.txt', 'file2 contents')
+          Dir.mkdir 'subdir'
+          File.write('subdir/file3.txt', 'file3 contents')
+          example.run
+        end
+      end
+
       context 'when told to add all changes into the index' do
         def untracked_entries
           worktree.status.entries.select { |entry| entry.is_a?(RubyGit::Status::UntrackedEntry) }
@@ -32,45 +33,31 @@ RSpec.describe RubyGit::Worktree do
     end
 
     describe 'calling the git add command line' do
+      let(:worktree) { described_class.new(worktree_path, normalize_path: false) }
+      let(:worktree_path) { '/some/worktree_path' } # Dummy path for testing
+
+      let(:subject_object) { worktree } # for the it_behaves_like 'it runs the git command'
       let(:result) { instance_double(RubyGit::CommandLine::Result, stdout: '') }
 
       context 'with called with no arguments' do
         let(:pathspecs) { [] }
         let(:options) { {} }
 
-        let(:expected_command) { %w[add] }
-
-        it 'should build the correct command' do
-          expect(worktree).to(
-            receive(:run).with(*expected_command, Hash)
-          ).and_return(result)
-
-          subject
-        end
-      end
-
-      RSpec.shared_examples 'the git command' do |expected_command|
-        it 'should build the correct command' do
-          expect(worktree).to(
-            receive(:run).with(*expected_command, Hash)
-          ).and_return(result)
-
-          subject
-        end
+        it_behaves_like 'it runs the git command', [%w[add]]
       end
 
       context 'with with a pathspec' do
         let(:pathspecs) { %w[file1.txt] }
         let(:options) { {} }
 
-        it_behaves_like 'the git command', %w[add -- file1.txt]
+        it_behaves_like 'it runs the git command', [%w[add -- file1.txt]]
       end
 
       context 'with two pathspecs' do
         let(:pathspecs) { %w[file1.txt file2.txt] }
         let(:options) { {} }
 
-        it_behaves_like 'the git command', %w[add -- file1.txt file2.txt]
+        it_behaves_like 'it runs the git command', [%w[add -- file1.txt file2.txt]]
       end
 
       context 'with the all option' do
@@ -78,14 +65,14 @@ RSpec.describe RubyGit::Worktree do
           let(:pathspecs) { [] }
           let(:options) { { all: true } }
 
-          it_behaves_like 'the git command', %w[add --all]
+          it_behaves_like 'it runs the git command', [%w[add --all]]
         end
 
         context 'all: false' do
           let(:pathspecs) { [] }
           let(:options) { { all: false } }
 
-          it_behaves_like 'the git command', %w[add]
+          it_behaves_like 'it runs the git command', [%w[add]]
         end
 
         context 'all: invalid' do
@@ -105,14 +92,14 @@ RSpec.describe RubyGit::Worktree do
           let(:pathspecs) { [] }
           let(:options) { { force: true } }
 
-          it_behaves_like 'the git command', %w[add --force]
+          it_behaves_like 'it runs the git command', [%w[add --force]]
         end
 
         context 'force: false' do
           let(:pathspecs) { [] }
           let(:options) { { force: false } }
 
-          it_behaves_like 'the git command', %w[add]
+          it_behaves_like 'it runs the git command', [%w[add]]
         end
 
         context 'force: invalid' do
@@ -132,14 +119,14 @@ RSpec.describe RubyGit::Worktree do
           let(:pathspecs) { [] }
           let(:options) { { update: true } }
 
-          it_behaves_like 'the git command', %w[add --update]
+          it_behaves_like 'it runs the git command', [%w[add --update]]
         end
 
         context 'update: false' do
           let(:pathspecs) { [] }
           let(:options) { { update: false } }
 
-          it_behaves_like 'the git command', %w[add]
+          it_behaves_like 'it runs the git command', [%w[add]]
         end
 
         context 'update: invalid' do
@@ -159,14 +146,14 @@ RSpec.describe RubyGit::Worktree do
           let(:pathspecs) { [] }
           let(:options) { { refresh: true } }
 
-          it_behaves_like 'the git command', %w[add --refresh]
+          it_behaves_like 'it runs the git command', [%w[add --refresh]]
         end
 
         context 'refresh: false' do
           let(:pathspecs) { [] }
           let(:options) { { refresh: false } }
 
-          it_behaves_like 'the git command', %w[add]
+          it_behaves_like 'it runs the git command', [%w[add]]
         end
 
         context 'refresh: invalid' do

--- a/spec/lib/ruby_git/worktree_open_spec.rb
+++ b/spec/lib/ruby_git/worktree_open_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe RubyGit::Worktree do
     context 'when worktree_path does not exist' do
       let(:worktree_path) { tmpdir }
       before { FileUtils.rmdir(worktree_path) }
-      it 'should  raise RubyGit::Error' do
-        expect { subject }.to raise_error(RubyGit::Error)
+      it 'should  raise ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
       end
     end
 
@@ -22,15 +22,15 @@ RSpec.describe RubyGit::Worktree do
         FileUtils.rmdir(worktree_path)
         FileUtils.touch(worktree_path)
       end
-      it 'should raise RubyGit::Error' do
-        expect { subject }.to raise_error(RubyGit::Error)
+      it 'should raise ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError)
       end
     end
 
     context 'when worktree_path exists but is not a git working tree' do
       let(:worktree_path) { tmpdir }
-      it 'should raise RubyGit::Error' do
-        expect { subject }.to raise_error(RubyGit::Error, /not a git repository/)
+      it 'should raise ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError, /not a git repository/)
       end
     end
 

--- a/spec/lib/ruby_git/worktree_spec.rb
+++ b/spec/lib/ruby_git/worktree_spec.rb
@@ -1,10 +1,50 @@
 # frozen_string_literal: true
 
 RSpec.describe RubyGit::Worktree do
-  describe '#repository' do
-    let(:worktree) { RubyGit::Worktree.open(worktree_path) }
-    let(:worktree_path) { @worktree_path }
+  let(:worktree) { RubyGit::Worktree.open(worktree_path, normalize_path:) }
+  let(:worktree_path) { '.' }
+  let(:normalize_path) { true }
 
+  describe '#initialize' do
+    subject { worktree }
+
+    around do |example|
+      in_temp_dir do
+        run %w[git init --initial-branch=main]
+        Dir.mkdir('subdir')
+        example.run
+      end
+    end
+
+    context 'when normalize_path is true' do
+      let(:normalize_path) { true }
+      context 'when worktree_path is the working tree root directory' do
+        let(:worktree_path) { '.' }
+        it 'should have a path to the working tree root directory' do
+          expected_path = File.realpath(File.expand_path(worktree_path))
+          expect(subject).to have_attributes(path: expected_path)
+        end
+      end
+
+      context 'when worktree_path is a subdirectory within the working tree' do
+        let(:worktree_path) { 'subdir' }
+        it 'should have a path to the working tree root directory' do
+          expected_path = File.realpath(File.expand_path('.'))
+          expect(subject).to have_attributes(path: expected_path)
+        end
+      end
+    end
+
+    context 'when normalize_path is false' do
+      let(:normalize_path) { false }
+      let(:worktree_path) { 'blah/blah/blah' }
+      it 'should have the given path' do
+        expect(subject).to have_attributes(path: worktree_path)
+      end
+    end
+  end
+
+  describe '#repository' do
     around do |example|
       in_temp_dir do |worktree_path|
         @worktree_path = worktree_path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -132,7 +132,64 @@ class String
   end
 end
 
+class Array
+  # Return a new array with old_value replaced with new_value
+  #
+  # @example
+  #   array = [1, 2, 3]
+  #   array.sub(2, 4) #=> [1, 4, 3]
+  #
+  # @param old_value [Object] The value to replace
+  # @param new_value [Object] The value to replace with
+  #
+  # @return [Array] A new array with the replaced value
+  #
+  def sub(old_value, new_value)
+    dup.tap do |new_array|
+      if (i = new_array.index(old_value))
+        new_array[i] = new_value
+      end
+    end
+  end
+end
+
 def eol = windows? ? "\r\n" : "\n"
+
+# RSpec shared example for testing that a subject will call the git command line
+# with the expected command and options.
+#
+# Must define the following context:
+#   * subject - the subject of the test
+#   * subject_object - the object that will receive the run_with_context method that will be mocked
+#   * result - the result of the command
+#
+# Assumes that the subject will call #run_with_context with the command and options.
+#
+# @example
+#   let(:subject) { worktree.add('file1.txt', 'file2.txt') }
+#   let(:subject_object) { worktree }
+#   let(:result) { instance_double(RubyGit::CommandLine::Result, stdout: '') }
+#   it_behaves_line 'it runs the git command', [%w[add -- file1.txt]]
+#
+RSpec.shared_examples 'it runs the git command' do |command, options = Hash|
+  it 'should build the correct command' do
+    if options.is_a?(Hash)
+      # If specific options are given, double splat them into the argument list
+      # binding.irb
+      expect(subject_object).to(
+        receive(:run_with_context).with(*command, **options)
+      ).and_return(result)
+    else
+      # Otherwise assume options is a RSpec construct
+      # binding.irb
+      expect(subject_object).to(
+        receive(:run_with_context).with(*command, options)
+      ).and_return(result)
+    end
+
+    subject
+  end
+end
 
 SimpleCov::RSpec.start(list_uncovered_lines: ci_build?)
 


### PR DESCRIPTION
This will make testing easier since the path normalization will not need
to be mocked.