### PR TITLE
Add `initial_branch:` option to `RubyGit::Worktree.init`

### DIFF
--- a/lib/ruby_git.rb
+++ b/lib/ruby_git.rb
@@ -3,6 +3,7 @@
 require_relative 'ruby_git/command_line'
 require_relative 'ruby_git/encoding_normalizer'
 require_relative 'ruby_git/errors'
+require_relative 'ruby_git/option_validators'
 require_relative 'ruby_git/repository'
 require_relative 'ruby_git/status'
 require_relative 'ruby_git/version'

--- a/lib/ruby_git/errors.rb
+++ b/lib/ruby_git/errors.rb
@@ -21,6 +21,7 @@ module RubyGit
   #     │   └─> RubyGit::SignaledError
   #     │       └─> RubyGit::TimeoutError
   #     ├─> RubyGit::ProcessIOError
+  #     ├─> RubyGit::SpawnError
   #     └─> RubyGit::UnexpectedResultError
   # ```
   #
@@ -32,6 +33,7 @@ module RubyGit
   # | `SignaledError` | This error is raised when the git command line is terminated as a result of receiving a signal. This could happen if the process is forcibly terminated or if there is a serious system error. |
   # | `TimeoutError` | This is a specific type of `SignaledError` that is raised when the git command line operation times out and is killed via the SIGKILL signal. This happens if the operation takes longer than the timeout duration configured in `Git.config.timeout` or via the `:timeout` parameter given in git methods that support timeouts. |
   # | `ProcessIOError` | An error was encountered reading or writing to a subprocess. |
+  # | `SpawnError` | An error was encountered when spawning a subprocess and it never started. |
   # | `UnexpectedResultError` | The command line ran without error but did not return the expected results. |
   #
   # @example Rescuing a generic error
@@ -166,4 +168,10 @@ module RubyGit
   # @api public
   #
   class UnexpectedResultError < RubyGit::Error; end
+
+  # Raised when the git command could not be spawned
+  #
+  # @api public
+  #
+  class SpawnError < RubyGit::Error; end
 end

--- a/lib/ruby_git/option_validators.rb
+++ b/lib/ruby_git/option_validators.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RubyGit
+  # Module containing option validators for RubyGit
+  # @api public
+  module OptionValidators
+    # Raise an error if an option is not a Boolean (or optionally nil) value
+    # @param name [String] the name of the option
+    # @param value [Object] the value of the option
+    # @param nullable [Boolean] whether the option can be nil (default is false)
+    # @return [void]
+    # @raise [ArgumentError] if the option is not a Boolean (or optionally nil) value
+    # @api private
+    def validate_boolean_option(name:, value:, nullable: false)
+      return if nullable && value.nil?
+
+      return if [true, false].include?(value)
+
+      raise ArgumentError, "The '#{name}:' option must be a Boolean value but was #{value.inspect}"
+    end
+
+    # Raise an error if an option is not a String (or optionally nil) value
+    # @param name [String] the name of the option
+    # @param value [Object] the value of the option
+    # @param nullable [Boolean] whether the option can be nil (default is false)
+    # @return [void]
+    # @raise [ArgumentError] if the option is not a String (or optionally nil) value
+    # @api private
+    def validate_string_option(name:, value:, nullable: false)
+      return if nullable && value.nil?
+
+      return if value.is_a?(String)
+
+      raise ArgumentError, "The '#{name}:' option must be a String or nil but was #{value.inspect}"
+    end
+  end
+end

--- a/lib/ruby_git/worktree.rb
+++ b/lib/ruby_git/worktree.rb
@@ -39,7 +39,7 @@ module RubyGit
     #
     # @return [RubyGit::Worktree] the working tree whose root is at `path`
     #
-    def self.init(worktree_path, initial_branch: nil) # rubocop:disable Metrics/MethodLength
+    def self.init(worktree_path, initial_branch: nil)
       validate_string_option(name: :initial_branch, value: initial_branch, nullable: true)
 
       command = ['init']
@@ -47,13 +47,7 @@ module RubyGit
 
       options = { chdir: worktree_path, out: StringIO.new, err: StringIO.new }
 
-      begin
-        RubyGit::CommandLine.run(*command, **options)
-      rescue Errno::ENOENT
-        raise ArgumentError, "Directory '#{worktree_path}' does not exist."
-      rescue Errno::ENOTDIR
-        raise ArgumentError, "Path '#{worktree_path}' is not a directory."
-      end
+      RubyGit::CommandLine.run(*command, **options)
 
       new(worktree_path)
     end

--- a/spec/lib/ruby_git/worktree_init_spec.rb
+++ b/spec/lib/ruby_git/worktree_init_spec.rb
@@ -20,8 +20,10 @@ RSpec.describe RubyGit::Worktree do
       context 'when worktree_path does not exist' do
         let(:worktree_path) { File.join(tmpdir, 'subdir') }
 
-        it 'should raise an ArgumentError' do
-          expect { subject }.to raise_error(ArgumentError)
+        expected_error = truffleruby? ? RubyGit::FailedError : RubyGit::SpawnError
+
+        it "should raise an error #{expected_error}" do
+          expect { subject }.to raise_error(expected_error)
         end
       end
 
@@ -32,8 +34,11 @@ RSpec.describe RubyGit::Worktree do
             FileUtils.rmdir(worktree_path)
             FileUtils.touch(worktree_path)
           end
-          it 'should raise an ArgumentError' do
-            expect { subject }.to raise_error(ArgumentError)
+
+          expected_error = truffleruby? ? RubyGit::FailedError : RubyGit::SpawnError
+
+          it "should raise a #{expected_error} " do
+            expect { subject }.to raise_error(expected_error)
           end
         end
 

--- a/spec/lib/ruby_git/worktree_init_spec.rb
+++ b/spec/lib/ruby_git/worktree_init_spec.rb
@@ -3,46 +3,114 @@
 require 'tmpdir'
 
 RSpec.describe RubyGit::Worktree do
-  describe '.init(worktree_path)' do
-    subject { described_class.init(worktree_path) }
-    let(:tmpdir) { Dir.mktmpdir }
-    after { FileUtils.rm_rf(tmpdir) }
+  describe '.init' do
+    subject { described_class.init(worktree_path, initial_branch: initial_branch) }
+    let(:initial_branch) { nil }
 
-    context 'when worktree_path does not exist' do
-      let(:worktree_path) { tmpdir }
-      before { FileUtils.rmdir(tmpdir) }
-      it 'should raise a RubyGit::Error' do
-        expect { subject }.to raise_error(RubyGit::Error)
+    describe 'initializing a worktree' do
+      let(:tmpdir) { @tmpdir }
+
+      around do |example|
+        in_temp_dir do |tmpdir|
+          @tmpdir = tmpdir
+          example.run
+        end
+      end
+
+      context 'when worktree_path does not exist' do
+        let(:worktree_path) { File.join(tmpdir, 'subdir') }
+
+        it 'should raise an ArgumentError' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'when worktree_path exists' do
+        let(:worktree_path) { tmpdir }
+        context 'and is not a directory' do
+          before do
+            FileUtils.rmdir(worktree_path)
+            FileUtils.touch(worktree_path)
+          end
+          it 'should raise an ArgumentError' do
+            expect { subject }.to raise_error(ArgumentError)
+          end
+        end
+
+        context 'and is a directory' do
+          context 'and is in a working tree' do
+            before do
+              raise RuntimeError unless system('git init', chdir: worktree_path, %i[out err] => IO::NULL)
+            end
+            it 'should return a Worktree object to the existing working tree' do
+              expect(subject).to be_kind_of(RubyGit::Worktree)
+              expect(subject).to have_attributes(path: File.realpath(worktree_path))
+            end
+          end
+
+          context 'and is not in the working tree' do
+            it 'should initialize the working tree and return a Worktree object' do
+              expect(subject).to be_kind_of(RubyGit::Worktree)
+              expect(subject).to have_attributes(path: File.realpath(worktree_path))
+            end
+          end
+        end
       end
     end
 
-    context 'when worktree_path exists' do
-      let(:worktree_path) { tmpdir }
-      context 'and is not a directory' do
-        before do
-          FileUtils.rmdir(worktree_path)
-          FileUtils.touch(worktree_path)
-        end
-        it 'should raise RubyGit::Error' do
-          expect { subject }.to raise_error(RubyGit::Error)
+    describe 'constructing the git command line' do
+      let(:worktree_path) { '/my/worktree/path' }
+      let(:result) { instance_double(RubyGit::CommandLine::Result, stdout: '') }
+
+      before do
+        allow(described_class).to(
+          receive(:new).with(worktree_path).and_return(instance_double(RubyGit::Worktree))
+        )
+      end
+
+      context 'called with no arguments' do
+        let(:expected_command) { %w[init] }
+
+        it 'should run the expected git command' do
+          expect(RubyGit::CommandLine).to(
+            receive(:run).with(*expected_command, Hash).and_return(result)
+          )
+
+          subject
         end
       end
 
-      context 'and is a directory' do
-        context 'and is in a working tree' do
-          before do
-            raise RuntimeError unless system('git init', chdir: worktree_path, %i[out err] => IO::NULL)
-          end
-          it 'should return a Worktree object to the existing working tree' do
-            expect(subject).to be_kind_of(RubyGit::Worktree)
-            expect(subject).to have_attributes(path: File.realpath(worktree_path))
+      describe 'initial_branch option' do
+        context 'when nil' do
+          let(:expected_command) { %w[init] }
+
+          it 'should run the expected git command' do
+            expect(RubyGit::CommandLine).to(
+              receive(:run).with(*expected_command, Hash).and_return(result)
+            )
+            subject
           end
         end
 
-        context 'and is not in the working tree' do
-          it 'should initialize the working tree and return a Worktree object' do
-            expect(subject).to be_kind_of(RubyGit::Worktree)
-            expect(subject).to have_attributes(path: File.realpath(worktree_path))
+        context 'when a string' do
+          let(:expected_command) { ['init', '--initial-branch', initial_branch] }
+          let(:initial_branch) { 'my-branch' }
+
+          it 'should run the expected git command' do
+            expect(RubyGit::CommandLine).to(
+              receive(:run).with(*expected_command, Hash).and_return(result)
+            )
+            subject
+          end
+        end
+
+        context 'when not a string' do
+          let(:initial_branch) { 123 }
+
+          it 'should raise an ArgumentError' do
+            expect { subject }.to(
+              raise_error(ArgumentError, %(The 'initial_branch:' option must be a String or nil but was 123))
+            )
           end
         end
       end


### PR DESCRIPTION
Allow the user to specify the initial branch in the newly created repository.

This also includes a refactoring to move option validation methods (like validate_boolean_option) to the RubyGit::OptionValidators module. This module is designed to be included and/or extended into classes needed to validate options.