### PR TITLE
Refine CI workflows for main and release PRs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,19 +36,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.1", "3.4"]
         operating-system: [ubuntu-latest]
         fail_on_low_coverage: [true]
-        include:
-          - ruby: "3.1"
-            operating-system: windows-latest
-            fail_on_low_coverage: false
-          - ruby: "jruby-9.4"
-            operating-system: ubuntu-latest
-            fail_on_low_coverage: false
-          - ruby: "truffleruby-24"
-            operating-system: ubuntu-latest
-            fail_on_low_coverage: false
 
     steps:
       - name: Checkout

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,9 +1,6 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [main]
-
   pull_request:
     branches: [main]
 
@@ -25,6 +22,10 @@ env:
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
 
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -9,6 +9,10 @@ jobs:
   commit-lint:
     name: Verify Conventional Commits
 
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -1,9 +1,6 @@
 name: Experimental Ruby Builds
 
 on:
-  push:
-    branches: [main]
-
   workflow_dispatch:
 
 env:

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -31,18 +31,27 @@ jobs:
       matrix:
         fail_on_low_coverage: [true]
         include:
+          - ruby: "3.1"
+            operating-system: windows-latest
+            fail_on_low_coverage: false
           - ruby: head
             operating-system: ubuntu-latest
           - ruby: head
             operating-system: windows-latest
+          - ruby: "truffleruby-24"
+            operating-system: ubuntu-latest
+            fail_on_low_coverage: false
           - ruby: truffleruby-head
             operating-system: ubuntu-latest
             fail_on_low_coverage: false
-          - ruby: jruby-head
+          - ruby: "jruby-9.4"
             operating-system: ubuntu-latest
             fail_on_low_coverage: false
           - ruby: "jruby-9.4"
             operating-system: windows-latest
+            fail_on_low_coverage: false
+          - ruby: jruby-head
+            operating-system: ubuntu-latest
             fail_on_low_coverage: false
           - ruby: jruby-head
             operating-system: windows-latest


### PR DESCRIPTION
Adjust CI workflows to prevent builds from triggering on merges to the main branch and for release PRs. Move unnecessary builds from the continuous integration workflow to the experimental Ruby builds.