### PR TITLE
Move option validators to a separate module

### DIFF
--- a/lib/ruby_git.rb
+++ b/lib/ruby_git.rb
@@ -3,6 +3,7 @@
 require_relative 'ruby_git/command_line'
 require_relative 'ruby_git/encoding_normalizer'
 require_relative 'ruby_git/errors'
+require_relative 'ruby_git/option_validators'
 require_relative 'ruby_git/repository'
 require_relative 'ruby_git/status'
 require_relative 'ruby_git/version'

--- a/lib/ruby_git/option_validators.rb
+++ b/lib/ruby_git/option_validators.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RubyGit
+  # Module containing option validators for RubyGit
+  # @api public
+  module OptionValidators
+    # Raise an error if an option is not a Boolean (or optionally nil) value
+    # @param name [String] the name of the option
+    # @param value [Object] the value of the option
+    # @param nullable [Boolean] whether the option can be nil (default is false)
+    # @return [void]
+    # @raise [ArgumentError] if the option is not a Boolean (or optionally nil) value
+    # @api private
+    def validate_boolean_option(name:, value:, nullable: false)
+      return if nullable && value.nil?
+
+      return if [true, false].include?(value)
+
+      raise ArgumentError, "The '#{name}:' option must be a Boolean value but was #{value.inspect}"
+    end
+
+    # Raise an error if an option is not a String (or optionally nil) value
+    # @param name [String] the name of the option
+    # @param value [Object] the value of the option
+    # @param nullable [Boolean] whether the option can be nil (default is false)
+    # @return [void]
+    # @raise [ArgumentError] if the option is not a String (or optionally nil) value
+    # @api private
+    def validate_string_option(name:, value:, nullable: false)
+      return if nullable && value.nil?
+
+      return if value.is_a?(String)
+
+      raise ArgumentError, "The '#{name}:' option must be a String or nil but was #{value.inspect}"
+    end
+  end
+end


### PR DESCRIPTION
Extract option validation logic into a dedicated module for better organization and maintainability.