### PR TITLE
Add initial_branch option to RubyGit.init

### DIFF
--- a/lib/ruby_git.rb
+++ b/lib/ruby_git.rb
@@ -80,16 +80,17 @@ module RubyGit
   # @see https://git-scm.com/docs/git-init git-init
   #
   # @example
-  #   worktree = Worktree.init(worktree_path)
+  #   worktree = Worktree.init(worktree_path, initial_branch: 'main')
   #
-  # @param [String] worktree_path the root path of a worktree
+  # @param worktree_path [String] the root path of a worktree
+  # @param initial_branch [String] the initial branch in the newly created repository
   #
   # @raise [RubyGit::Error] if worktree_path is not a directory
   #
   # @return [RubyGit::Worktree] the worktree whose root is at `path`
   #
-  def self.init(worktree_path)
-    RubyGit::Worktree.init(worktree_path)
+  def self.init(worktree_path, initial_branch:)
+    RubyGit::Worktree.init(worktree_path, initial_branch:)
   end
 
   # Open an existing Git working tree that contains worktree_path

--- a/lib/ruby_git/worktree.rb
+++ b/lib/ruby_git/worktree.rb
@@ -29,7 +29,7 @@ module RubyGit
     # @see https://git-scm.com/docs/git-init git-init
     #
     # @example
-    #   worktree = Worktree.init(worktree_path)
+    #   worktree = Worktree.init(worktree_path, initial_branch: 'main')
     #
     # @param worktree_path [String] the root path of a Git working tree
     # @param initial_branch [String] the initial branch in the newly created repository

--- a/spec/lib/ruby_git_spec.rb
+++ b/spec/lib/ruby_git_spec.rb
@@ -40,12 +40,13 @@ RSpec.describe RubyGit do
   end
 
   describe '.init' do
+    subject { RubyGit.init(worktree_path, initial_branch:) }
     let(:worktree_path) { '/Users/jsmith/my_project' }
-    subject { RubyGit.init(worktree_path) }
+    let(:initial_branch) { 'xxx' }
     it 'should call RubyGit::Worktree.init with the same arguments' do
       worktree_class = class_double('RubyGit::Worktree')
       stub_const('RubyGit::Worktree', worktree_class)
-      expect(worktree_class).to receive(:init).with(worktree_path)
+      expect(worktree_class).to receive(:init).with(worktree_path, initial_branch:)
       subject
     end
   end


### PR DESCRIPTION
Introduce an option to specify the initial branch when initializing a new worktree in RubyGit. This enhancement allows users to set a default branch name during repository creation.