### PR TITLE
fix: update changelog sections in release-please-config

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -14,3 +14,20 @@ rules:
   #
   body-leading-blank:    [2, 'always']
   footer-leading-blank:  [2, 'always']
+  type-enum: [
+    2,
+    'always',
+    [
+      'build',
+      'ci',
+      'chore',
+      'docs',
+      'feat',
+      'fix',
+      'perf',
+      'refactor',
+      'revert',
+      'style',
+      'test'
+    ]
+  ]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,20 @@
       "draft": true,
       "prerelease": false,
       "include-component-in-tag": false,
-      "pull-request-title-pattern": "chore: release v${version}"
+      "pull-request-title-pattern": "chore: release v${version}",
+      "changelog-sections": [
+        { "type": "feat",     "section": "Features",      "hidden": false },
+        { "type": "fix",      "section": "Bug Fixes",     "hidden": false },
+        { "type": "build",    "section": "Other Changes", "hidden": false },
+        { "type": "chore",    "section": "Other Changes", "hidden": false },
+        { "type": "ci",       "section": "Other Changes", "hidden": false }
+        { "type": "docs",     "section": "Other Changes", "hidden": false },
+        { "type": "perf",     "section": "Other Changes", "hidden": false },
+        { "type": "refactor", "section": "Other Changes", "hidden": false },
+        { "type": "revert",   "section": "Other Changes", "hidden": false },
+        { "type": "style",    "section": "Other Changes", "hidden": false },
+        { "type": "test",     "section": "Other Changes", "hidden": false },
+      ]
     }
   },
   "plugins": [


### PR DESCRIPTION
There are two changes made to the release-please config:
(1) all change types will be show where many where hidden before
(2) the change types that were hidden before are grouped into a section called
"Other Changes"

Also the supported conventions commit change types rae explicitly listed in
the commitlintrc.yml so we can ensure that they align with the
release-please configuration.