### PR TITLE
Upgrade process_executer dependency to 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in ruby_git.gemspec
 gemspec

--- a/lib/ruby_git.rb
+++ b/lib/ruby_git.rb
@@ -160,9 +160,7 @@ module RubyGit
   #   or git was not found on the path.
   #
   def self.binary_version
-    command = %w[version]
-    options = { out: StringIO.new, err: StringIO.new }
-    version_string = RubyGit::CommandLine.run(*command, **options).stdout[/\d+\.\d+(\.\d+)+/]
+    version_string = RubyGit::CommandLine.run('version').stdout[/\d+\.\d+(\.\d+)+/]
     version_string.split('.').collect(&:to_i)
   end
 end

--- a/lib/ruby_git/command_line/options.rb
+++ b/lib/ruby_git/command_line/options.rb
@@ -9,13 +9,11 @@ module RubyGit
     #
     # @api public
     #
-    class Options < ProcessExecuter::Options::RunOptions
+    class Options < ProcessExecuter::Options::RunWithCaptureOptions
       # Alias for brevity
       OptionDefinition = ProcessExecuter::Options::OptionDefinition
 
       private
-
-      # :nocov: SimpleCov on JRuby reports the last with the last argument line is not covered
 
       # The options allowed for objects of this class
       # @return [Array<OptionDefinition>]
@@ -24,25 +22,24 @@ module RubyGit
         [
           *super,
           OptionDefinition.new(:normalize_encoding, default: false, validator: method(:validate_normalize_encoding)),
-          OptionDefinition.new(:chomp, default: false, validator: method(:validate_chomp)),
-          OptionDefinition.new(:raise_git_errors, default: true, validator: method(:validate_raise_git_errors))
+          OptionDefinition.new(:chomp, default: false, validator: method(:validate_chomp))
         ].freeze
       end
-      # :nocov:
 
-      # Validate the raise_git_errors option value
-      # @return [String, nil] the error message if the value is not valid
+      # Wrap ProcessExecuter::ArgumentError in a RubyGit::ArgumentError
+      # @return [void]
+      # @raise [RubyGit::ArgumentError] if the options are invalid
       # @api private
-      def validate_raise_git_errors
-        return if [true, false].include?(raise_git_errors)
-
-        errors << "raise_git_errors must be true or false but was #{raise_git_errors.inspect}"
+      def validate_options
+        super
+      rescue ProcessExecuter::ArgumentError => e
+        raise RubyGit::ArgumentError, e.message, cause: e
       end
 
       # Validate the normalize_encoding option value
       # @return [String, nil] the error message if the value is not valid
       # @api private
-      def validate_normalize_encoding
+      def validate_normalize_encoding(_key, _value)
         return if [true, false].include?(normalize_encoding)
 
         errors << "normalize_encoding must be true or false but was #{normalize_encoding.inspect}"
@@ -51,7 +48,7 @@ module RubyGit
       # Validate the chomp option value
       # @return [String, nil] the error message if the value is not valid
       # @api private
-      def validate_chomp
+      def validate_chomp(_key, _value)
         return if [true, false].include?(chomp)
 
         errors << "chomp must be true or false but was #{chomp.inspect}"

--- a/lib/ruby_git/command_line/result.rb
+++ b/lib/ruby_git/command_line/result.rb
@@ -7,27 +7,30 @@ module RubyGit
   module CommandLine
     # The result of running a git command
     #
-    # Adds stdout and stderr processing to the `ProcessExecuter::Result` class.
+    # Adds stdout and stderr processing to the `ProcessExecuter::ResultWithCapture` class.
     #
     # @api public
     #
     class Result < SimpleDelegator
       # @!method initialize(result)
       #   Initialize a new result object
+      #
       #   @example
-      #     result = ProcessExecuter.run('echo hello')
+      #     result = Git::CommandLine.run_with_capture('git', 'status')
       #     RubyGit::CommandLine::Result.new(result)
-      #   @param [ProcessExecuter::Result] result The result of running the command
+      #
+      #   @param [ProcessExecuter::ResultWithCapture] result The result of running the command
+      #
       #   @return [RubyGit::CommandLine::Result]
+      #
       #   @api public
 
       # Return the processed stdout output (or original if it was not processed)
       #
-      # This output is only returned if a stdout redirection is a
-      # `ProcessExecuter::MonitoredPipe`.
-      #
       # @example
-      #   result = ProcessExecuter.run('echo hello': out: StringIO.new)
+      #   result = RubyGit::CommandLine::Result.new(
+      #     ProcessExecuter.run_with_capture('echo hello')
+      #   )
       #   result.stdout #=> "hello\n"
       #
       # @return [String, nil]
@@ -39,20 +42,25 @@ module RubyGit
       # Process the captured stdout output
       #
       # @example
-      #   result = ProcessExecuter.run('echo hello', out: StringIO.new)
+      #   result = RubyGit::CommandLine::Result.new(
+      #     ProcessExecuter.run_with_capture('echo hello')
+      #   )
       #   result.stdout #=> "hello\n"
       #   result.process_stdout { |stdout, _result| stdout.upcase }
       #   result.stdout #=> "HELLO\n"
       #   result.unprocessed_stdout #=> "hello\n"
       #
       # @example Chain processing
-      #   result = ProcessExecuter.run('echo hello', out: StringIO.new)
+      #   result = RubyGit::CommandLine::Result.new(
+      #     ProcessExecuter.run_with_capture('echo hello')
+      #   )
       #   result.stdout #=> "hello\n"
+      #   # Here is the chain processing:
       #   result.process_stdout { |s| s.upcase }.process_stdout { |s| s.reverse }
       #   result.stdout #=> "OLLEH\n"
       #   result.unprocessed_stdout #=> "hello\n"
       #
-      # @return [String, nil]
+      # @return [self]
       #
       # @yield [stdout, result] Yields the stdout output and the result object
       # @yieldparam stdout [String] The output to process
@@ -62,16 +70,19 @@ module RubyGit
       # @api public
       #
       def process_stdout(&block)
-        return if block.nil?
+        return self if block.nil?
 
         @processed_stdout = block.call(stdout, self)
+
         self
       end
 
       # Returns the original stdout output before it was processed
       #
       # @example
-      #   result = ProcessExecuter.run('echo hello', out: StringIO.new)
+      #   result = RubyGit::CommandLine::Result.new(
+      #     ProcessExecuter.run_with_capture('echo hello')
+      #   )
       #   result.stdout #=> "hello\n"
       #   result.unprocessed_stdout #=> "hello\n"
       #   result.process_stdout { |s| s.upcase }
@@ -92,7 +103,9 @@ module RubyGit
       # `ProcessExecuter::MonitoredPipe`.
       #
       # @example
-      #   result = ProcessExecuter.run('echo hello 1>&2': err: StringIO.new)
+      #   result = RubyGit::CommandLine::Result.new(
+      #     ProcessExecuter.run_with_capture('echo hello >&2')
+      #   )
       #   result.stderr #=> "hello\n"
       #
       # @return [String, nil]
@@ -104,20 +117,25 @@ module RubyGit
       # Process the captured stderr output
       #
       # @example
-      #   result = ProcessExecuter.run('echo hello 1>&2', err: StringIO.new)
+      #   result = RubyGit::CommandLine::Result.new(
+      #     ProcessExecuter.run_with_capture('echo hello >&2')
+      #   )
       #   result.stderr #=> "hello\n"
       #   result.process_stderr { |stderr, _result| stderr.upcase }
       #   result.stderr #=> "HELLO\n"
       #   result.unprocessed_stderr #=> "hello\n"
       #
       # @example Chain processing
-      #   result = ProcessExecuter.run('echo hello 1>&2', err: StringIO.new)
+      #   result = RubyGit::CommandLine::Result.new(
+      #     ProcessExecuter.run_with_capture('echo hello >&2')
+      #   )
       #   result.stderr #=> "hello\n"
+      #   # Here is the chain processing:
       #   result.process_stderr { |s| s.upcase }.process_stderr { |s| s.reverse }
       #   result.stderr #=> "OLLEH\n"
       #   result.unprocessed_stderr #=> "hello\n"
       #
-      # @return [String, nil]
+      # @return [self]
       #
       # @yield [stderr, result] Yields the stderr output and the result object
       # @yieldparam stderr [String] The output to process
@@ -127,16 +145,19 @@ module RubyGit
       # @api public
       #
       def process_stderr(&block)
-        return if block.nil?
+        return self if block.nil?
 
         @processed_stderr = block.call(stderr, self)
+
         self
       end
 
       # Returns the original stderr output before it was processed
       #
       # @example
-      #   result = ProcessExecuter.run('echo hello 1>&2', err: StringIO.new)
+      #   result = RubyGit::CommandLine::Result.new(
+      #     ProcessExecuter.run_with_capture('echo hello >&2')
+      #   )
       #   result.stderr #=> "hello\n"
       #   result.unprocessed_stderr #=> "hello\n"
       #   result.process_stderr { |stderr| stderr.upcase }

--- a/lib/ruby_git/errors.rb
+++ b/lib/ruby_git/errors.rb
@@ -16,6 +16,7 @@ module RubyGit
   # ```text
   # StandardError
   # └─> RubyGit::Error
+  #     ├─> RubyGit::ArgumentError
   #     ├─> RubyGit::CommandLineError
   #     │   ├─> RubyGit::FailedError
   #     │   └─> RubyGit::SignaledError
@@ -28,6 +29,7 @@ module RubyGit
   # | Error Class | Description |
   # | --- | --- |
   # | `Error` | This catch-all error serves as the base class for other custom errors raised by the git gem. |
+  # | `ArgumentError` | Raised when an invalid argument is passed to a method. |
   # | `CommandLineError` | A subclass of this error is raised when there is a problem executing the git command line. |
   # | `FailedError` | This error is raised when the git command line exits with a non-zero status code that is not expected by the git gem. |
   # | `SignaledError` | This error is raised when the git command line is terminated as a result of receiving a signal. This could happen if the process is forcibly terminated or if there is a serious system error. |
@@ -65,6 +67,19 @@ module RubyGit
   class Error < StandardError; end
 
   # rubocop:enable Layout/LineLength
+
+  # Raised when an invalid argument is passed to a method
+  #
+  # @example Raising RubyGit::ArgumentError due to invalid option value
+  #   begin
+  #     RubyGit::CommandLine.run('status', timeout_after: 'not_a_number')
+  #   rescue RubyGit::ArgumentError => e
+  #     e.message #=> 'timeout_after must be nil or a non-negative real number but was "not_a_number"'
+  #   end
+  #
+  # @api public
+  #
+  class ArgumentError < RubyGit::Error; end
 
   # Raised when a git command fails or exits because of an uncaught signal
   #

--- a/ruby_git.gemspec
+++ b/ruby_git.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency 'yardstick', '~> 0.9'
   end
 
-  spec.add_dependency 'process_executer', '~> 3.2'
+  spec.add_dependency 'process_executer', '~> 4.0'
   spec.add_dependency 'rchardet', '~> 1.9'
 
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/spec/lib/ruby_git/command_line/options_spec.rb
+++ b/spec/lib/ruby_git/command_line/options_spec.rb
@@ -12,22 +12,14 @@ RSpec.describe RubyGit::CommandLine::Options do
     subject { options }
 
     it 'should have attributes with default values' do
-      expect(subject).to have_attributes(raise_git_errors: true, normalize_encoding: false, chomp: false)
+      expect(subject).to have_attributes(normalize_encoding: false, chomp: false)
     end
 
     context 'when options are passed' do
-      let(:options_hash) { { raise_git_errors: false, normalize_encoding: true, chomp: true } }
+      let(:options_hash) { { normalize_encoding: true, chomp: true } }
 
       it 'should have the passed attributes' do
-        expect(subject).to have_attributes(raise_git_errors: false, normalize_encoding: true, chomp: true)
-      end
-    end
-
-    context 'when raise_git_errors is not valid' do
-      let(:options_hash) { { raise_git_errors: 'not a boolean' } }
-
-      it 'should raise an error' do
-        expect { subject }.to raise_error(ArgumentError, /raise_git_errors/)
+        expect(subject).to have_attributes(normalize_encoding: true, chomp: true)
       end
     end
 
@@ -35,7 +27,7 @@ RSpec.describe RubyGit::CommandLine::Options do
       let(:options_hash) { { normalize_encoding: 'not a boolean' } }
 
       it 'should raise an error' do
-        expect { subject }.to raise_error(ArgumentError, /normalize_encoding/)
+        expect { subject }.to raise_error(RubyGit::ArgumentError, /normalize_encoding/)
       end
     end
 
@@ -43,7 +35,7 @@ RSpec.describe RubyGit::CommandLine::Options do
       let(:options_hash) { { chomp: 'not a boolean' } }
 
       it 'should raise an error' do
-        expect { subject }.to raise_error(ArgumentError, /chomp/)
+        expect { subject }.to raise_error(RubyGit::ArgumentError, /chomp/)
       end
     end
   end

--- a/spec/lib/ruby_git/command_line/result_spec.rb
+++ b/spec/lib/ruby_git/command_line/result_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RubyGit::CommandLine::Result do
   let(:result) { described_class.new(process_executer_result) }
-  let(:process_executer_result) { ProcessExecuter.run(*command, **options) }
+  let(:process_executer_result) { ProcessExecuter.run_with_capture(*command, **options) }
   let(:command) { ruby_command <<~RUBY }
     STDOUT.puts 'stdout message'
     STDERR.puts 'stderr message'
@@ -60,7 +60,7 @@ RSpec.describe RubyGit::CommandLine::Result do
 
     context 'when #process_stdout HAS been called' do
       it 'should return the original stdout' do
-        result.process_stdout { |s, _r| s.upcase! }
+        result.process_stdout { |s, _r| s.upcase }
         expect(result.unprocessed_stdout).to eq("stdout message#{eol}")
       end
     end
@@ -119,7 +119,7 @@ RSpec.describe RubyGit::CommandLine::Result do
 
     context 'when #process_stderr HAS been called' do
       it 'should return the original stderr' do
-        result.process_stderr { |s, _r| s.upcase! }
+        result.process_stderr { |s, _r| s.upcase }
         expect(result.unprocessed_stderr.with_linux_eol).to eq("stderr message\n")
       end
     end

--- a/spec/lib/ruby_git/command_line/runner_spec.rb
+++ b/spec/lib/ruby_git/command_line/runner_spec.rb
@@ -45,18 +45,18 @@ RSpec.describe RubyGit::CommandLine::Runner do
       logger = Logger.new(nil)
 
       expected_command = [env, binary_path, *global_options, *args]
-      expected_options = { raise_git_errors: false, logger: Logger }
+      expected_options = { raise_errors: false, logger: Logger }
 
       runner = described_class.new(env, binary_path, global_options, logger)
 
       expect(ProcessExecuter).to(
-        receive(:run_with_options).with(
-          expected_command, an_object_having_attributes(**expected_options)
+        receive(:run_with_capture).with(
+          *expected_command, an_object_having_attributes(**expected_options)
         ).and_call_original
       )
 
       runner.call(
-        *args, chomp: true, raise_git_errors: false, out: StringIO.new, err: StringIO.new, logger:
+        *args, chomp: true, raise_errors: false, out: StringIO.new, err: StringIO.new, logger:
       )
     end
 
@@ -64,8 +64,8 @@ RSpec.describe RubyGit::CommandLine::Runner do
     let(:env) { {} }
     let(:binary_path) { 'ruby' }
     let(:global_options) { ['bin/command-line-test'] }
-    let(:options) { { raise_git_errors:, timeout_after:, chomp: } }
-    let(:raise_git_errors) { true }
+    let(:options) { { raise_errors:, timeout_after:, chomp: } }
+    let(:raise_errors) { true }
     let(:timeout_after) { nil }
     let(:chomp) { false }
 
@@ -84,14 +84,14 @@ RSpec.describe RubyGit::CommandLine::Runner do
         }
       end
 
-      context 'when raise_git_errors is true' do
-        let(:raise_git_errors) { true }
+      context 'when raise_errors is true' do
+        let(:raise_errors) { true }
 
         it { is_expected.to have_attributes(expected_result_attributes) }
       end
 
-      context 'when raise_git_errors is false' do
-        let(:raise_git_errors) { false }
+      context 'when raise_errors is false' do
+        let(:raise_errors) { false }
 
         it { is_expected.to have_attributes(expected_result_attributes) }
       end
@@ -110,8 +110,8 @@ RSpec.describe RubyGit::CommandLine::Runner do
         }
       end
 
-      context 'when raise_git_errors is true' do
-        let(:raise_git_errors) { true }
+      context 'when raise_errors is true' do
+        let(:raise_errors) { true }
 
         it 'should raise a RubyGit::FailedError' do
           expect { subject }.to raise_error(RubyGit::FailedError) do |e|
@@ -120,8 +120,8 @@ RSpec.describe RubyGit::CommandLine::Runner do
         end
       end
 
-      context 'when raise_git_errors is false' do
-        let(:raise_git_errors) { false }
+      context 'when raise_errors is false' do
+        let(:raise_errors) { false }
 
         it 'should return a result indicating the failure' do
           expect(subject).to have_attributes(expected_result_attributes)
@@ -142,8 +142,8 @@ RSpec.describe RubyGit::CommandLine::Runner do
         }
       end
 
-      context 'when raise_git_errors is true' do
-        let(:raise_git_errors) { true }
+      context 'when raise_errors is true' do
+        let(:raise_errors) { true }
 
         it 'should raise a RubyGit::SignaledError' do
           expect { subject }.to raise_error(RubyGit::SignaledError) do |e|
@@ -152,8 +152,8 @@ RSpec.describe RubyGit::CommandLine::Runner do
         end
       end
 
-      context 'when raise_git_errors is false' do
-        let(:raise_git_errors) { false }
+      context 'when raise_errors is false' do
+        let(:raise_errors) { false }
 
         it 'should return a result indicating the signal' do
           expect(subject).to have_attributes(expected_result_attributes)
@@ -183,8 +183,8 @@ RSpec.describe RubyGit::CommandLine::Runner do
       end
       # :nocov:
 
-      context 'when raise_git_errors is true' do
-        let(:raise_git_errors) { true }
+      context 'when raise_errors is true' do
+        let(:raise_errors) { true }
         let(:timeout_after) { 0.05 }
 
         it 'should raise a RubyGit::SignaledError' do
@@ -194,8 +194,8 @@ RSpec.describe RubyGit::CommandLine::Runner do
         end
       end
 
-      context 'when raise_git_errors is false' do
-        let(:raise_git_errors) { false }
+      context 'when raise_errors is false' do
+        let(:raise_errors) { false }
         let(:timeout_after) { 0.05 }
 
         it 'should return a result indicating the signal' do
@@ -234,7 +234,7 @@ RSpec.describe RubyGit::CommandLine::Runner do
     end
 
     describe 'encoding normalization of output' do
-      let(:options) { { out: StringIO.new, err: StringIO.new, normalize_encoding: } }
+      let(:options) { { normalize_encoding: } }
 
       let(:expected_non_normalized_output) do
         String.new(
@@ -243,7 +243,7 @@ RSpec.describe RubyGit::CommandLine::Runner do
           "\xCD\xEF \xE8\xF1\xE2\xE1\xED\xE9\xF4\xE1\xF3\n" \
           "\xD6\xE5\xE8\xE3\xE9\xE1\xF4 \xE8\xF1\xE2\xE1\xED\xE9\xF4\xE1\xF3 " \
           "\xF1\xE5\xF0\xF1\xE9\xEC\xE9q\xE8\xE5\n"
-        ).force_encoding('ASCII-8BIT')
+        ).force_encoding(Encoding.default_external)
       end
 
       let(:expected_normalized_output) { <<~OUTPUT }
@@ -288,18 +288,18 @@ RSpec.describe RubyGit::CommandLine::Runner do
         end.new
       end
 
-      let(:options) { { raise_git_errors:, out: } }
+      let(:options) { { raise_errors:, out: } }
 
-      context 'when :raise_git_errors is true' do
-        let(:raise_git_errors) { true }
+      context 'when :raise_errors is true' do
+        let(:raise_errors) { true }
 
         it 'should raise a RubyGit::ProcessIOError' do
           expect { subject }.to raise_error(RubyGit::ProcessIOError)
         end
       end
 
-      context 'when :raise_git_errors is false' do
-        let(:raise_git_errors) { false }
+      context 'when :raise_errors is false' do
+        let(:raise_errors) { false }
 
         it 'should raise a RubyGit::ProcessIOError (even if told not to raise errors)' do
           expect { subject }.to raise_error(RubyGit::ProcessIOError)

--- a/spec/lib/ruby_git/worktree_add_spec.rb
+++ b/spec/lib/ruby_git/worktree_add_spec.rb
@@ -79,7 +79,8 @@ RSpec.describe RubyGit::Worktree do
           let(:pathspecs) { [] }
           let(:options) { { all: 'invalid' } }
 
-          it_behaves_like 'it raises an ArgumentError', %(The 'all:' option must be a Boolean value but was "invalid")
+          it_behaves_like 'it raises a RubyGit::ArgumentError',
+                          %(The 'all:' option must be a Boolean value but was "invalid")
         end
       end
 
@@ -103,7 +104,7 @@ RSpec.describe RubyGit::Worktree do
           let(:options) { { force: 'invalid' } }
 
           it_behaves_like(
-            'it raises an ArgumentError',
+            'it raises a RubyGit::ArgumentError',
             %(The 'force:' option must be a Boolean value but was "invalid")
           )
         end
@@ -129,7 +130,7 @@ RSpec.describe RubyGit::Worktree do
           let(:options) { { update: 'invalid' } }
 
           it_behaves_like(
-            'it raises an ArgumentError',
+            'it raises a RubyGit::ArgumentError',
             %(The 'update:' option must be a Boolean value but was "invalid")
           )
         end
@@ -155,7 +156,7 @@ RSpec.describe RubyGit::Worktree do
           let(:options) { { refresh: 'invalid' } }
 
           it_behaves_like(
-            'it raises an ArgumentError',
+            'it raises a RubyGit::ArgumentError',
             %(The 'refresh:' option must be a Boolean value but was "invalid")
           )
         end

--- a/spec/lib/ruby_git/worktree_init_spec.rb
+++ b/spec/lib/ruby_git/worktree_init_spec.rb
@@ -112,11 +112,10 @@ RSpec.describe RubyGit::Worktree do
         context 'when not a string' do
           let(:initial_branch) { 123 }
 
-          it 'should raise an ArgumentError' do
-            expect { subject }.to(
-              raise_error(ArgumentError, %(The 'initial_branch:' option must be a String or nil but was 123))
-            )
-          end
+          it_behaves_like(
+            'it raises a RubyGit::ArgumentError',
+            %(The 'initial_branch:' option must be a String or nil but was 123)
+          )
         end
       end
     end

--- a/spec/lib/ruby_git/worktree_open_spec.rb
+++ b/spec/lib/ruby_git/worktree_open_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RubyGit::Worktree do
       let(:worktree_path) { tmpdir }
       before { FileUtils.rmdir(worktree_path) }
       it 'should  raise ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
+        expect { subject }.to raise_error(RubyGit::ArgumentError)
       end
     end
 
@@ -23,14 +23,14 @@ RSpec.describe RubyGit::Worktree do
         FileUtils.touch(worktree_path)
       end
       it 'should raise ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError)
+        expect { subject }.to raise_error(RubyGit::ArgumentError)
       end
     end
 
     context 'when worktree_path exists but is not a git working tree' do
       let(:worktree_path) { tmpdir }
       it 'should raise ArgumentError' do
-        expect { subject }.to raise_error(ArgumentError, /not a git repository/)
+        expect { subject }.to raise_error(RubyGit::ArgumentError, /not a git repository/)
       end
     end
 

--- a/spec/lib/ruby_git_spec.rb
+++ b/spec/lib/ruby_git_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe RubyGit do
       let(:git_version_string) { 'git version 10.11.12' }
       let(:result) { double(RubyGit::CommandLine::Result, stdout: git_version_string) }
       it 'should return [10, 11, 12]' do
-        expect(RubyGit::CommandLine).to receive(:run).with('version', Hash).and_return(result)
+        expect(RubyGit::CommandLine).to receive(:run).with('version').and_return(result)
         expect(subject).to eq([10, 11, 12])
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,7 +53,7 @@ end
 
 def run(*command)
   command = command[0] if command.size == 1 && command[0].is_a?(Array)
-  ProcessExecuter.run(*command, out: StringIO.new, err: StringIO.new)
+  ProcessExecuter.run_with_capture(*command)
 end
 
 def status_output
@@ -195,13 +195,13 @@ RSpec.shared_examples 'it runs the git command' do |command, options = Hash|
   end
 end
 
-RSpec.shared_examples 'it raises an ArgumentError' do |message|
-  it 'should raise an Argument' do
+RSpec.shared_examples 'it raises a RubyGit::ArgumentError' do |message|
+  it 'should raise an RubyGit::ArgumentError' do
     allow_any_instance_of(described_class).to(
       receive(:normalize_path) { |_, path| path }
     )
 
-    expect { subject }.to(raise_error(ArgumentError, message))
+    expect { subject }.to(raise_error(RubyGit::ArgumentError, message))
   end
 end
 


### PR DESCRIPTION
**BREAKING CHANGE**: RubyGit::CommandLine.run no longer accepts the option
`raise_git_errors: <Boolean>`. Users should use `raise_errors: <Boolean>` instead.

**BREAKING CHANGE**: this gem now raises `RubyGit::ArgumentError` where before it raised
`::ArgumentError`
